### PR TITLE
fix(ui): align sidebar end margins with window chrome

### DIFF
--- a/crates/ui/src/player/lyrics/view.rs
+++ b/crates/ui/src/player/lyrics/view.rs
@@ -10,6 +10,8 @@ use lyrics::{
     japanese_reading_for_language_options,
 };
 
+use crate::shell::layout::WINDOW_CHROME_MARGIN_END;
+
 use super::wrapping_line::WrappingLine;
 
 const DEFAULT_LYRICS_SCROLL_ANIMATION_MS: u64 = 300;
@@ -140,7 +142,7 @@ impl LyricsPane {
 
         let body = gtk::Box::new(gtk::Orientation::Vertical, 6);
         body.set_vexpand(true);
-        body.set_margin_end(8);
+        body.set_margin_end(WINDOW_CHROME_MARGIN_END);
         body.add_css_class("lyrics-lines");
         scroller.set_child(Some(&body));
         root.set_child(Some(&scroller));

--- a/crates/ui/src/player/queue.rs
+++ b/crates/ui/src/player/queue.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use crate::format_duration;
 use crate::routes::detail_links::{DetailLinkBinding, track_artist_links};
 use crate::routes::route::Route;
+use crate::shell::layout::WINDOW_CHROME_MARGIN_END;
 use ::library::{AcceptedTrackReplacement, MetadataItemId, RadioSeed, Track, TrackId};
 use adw::prelude::*;
 use artwork::ArtworkBinding;
@@ -192,6 +193,7 @@ impl QueueSidebarRowSlot {
         let stack = gtk::Stack::new();
         stack.set_hexpand(true);
         stack.set_halign(gtk::Align::Fill);
+        stack.set_margin_end(WINDOW_CHROME_MARGIN_END);
 
         let row = gtk::Box::new(gtk::Orientation::Horizontal, 8);
         row.add_css_class("queue-row");


### PR DESCRIPTION
## Description

Follow-up to #783 / discussion in #761:

- Apply `WINDOW_CHROME_MARGIN_END` to `QueueSidebarRowSlot` so queue rows have proper end margin.
- Replace hardcoded margin in `LyricsPane` with `WINDOW_CHROME_MARGIN_END` for consistency.

## Screenshots

|As-Is|To-Be|
|-|-|
|<img width="150" alt="Screenshot From 2026-08-23 03-47-15" src="https://github.com/user-attachments/assets/04205660-9804-4d66-8309-b1b64c6d2f09" /><img width="150" alt="Screenshot From 2026-08-23 03-48-39" src="https://github.com/user-attachments/assets/24c727aa-fd4f-4de2-82a4-21e77c7a8dd8" />|<img width="150" alt="Screenshot From 2026-08-23 03-47-50" src="https://github.com/user-attachments/assets/7c4627c4-471b-46e6-aa2d-713108626510" /><img width="150" alt="Screenshot From 2026-08-23 03-48-12" src="https://github.com/user-attachments/assets/3503c020-a0e9-4997-a7b7-ef7ae9ab5c4d" />|




