### PR TITLE
feat(lyrics): new lyrics features with save, editor, and typography settings

### DIFF
--- a/crates/library/src/local.rs
+++ b/crates/library/src/local.rs
@@ -247,6 +247,25 @@ impl Database {
         Ok(rows?)
     }
 
+    pub async fn mapping_track_source_path(
+        &self,
+        source: SourceKey,
+        track: TrackKey,
+        cancellation: &ReadCancellation,
+    ) -> LibraryResult<Option<String>> {
+        let (_permit, mut connection) = self.acquire_general(cancellation).await?;
+        let path = sqlx::query_scalar(
+            "SELECT source_path FROM tracks
+             WHERE source_key=?1 AND track_key=?2 AND source_path IS NOT NULL",
+        )
+        .bind(source)
+        .bind(track)
+        .fetch_optional(&mut *connection)
+        .await;
+        Database::clear_progress(&mut connection).await?;
+        Ok(path?)
+    }
+
     pub async fn mapping_track_object(
         &self,
         source: SourceKey,

--- a/crates/library/src/lyrics.rs
+++ b/crates/library/src/lyrics.rs
@@ -55,6 +55,7 @@ impl Database {
         language: &str,
         script: &str,
         cache_input_digest: [u8; 32],
+        prefer_source: bool,
         cancellation: &ReadCancellation,
     ) -> LibraryResult<Option<LyricsCacheRow>> {
         let (_permit, mut connection) = self.acquire_general(cancellation).await?;
@@ -62,7 +63,7 @@ impl Database {
             "SELECT authority,role,language,script,cache_input_digest,lyrics,updated_at
              FROM lyrics_cache WHERE source_key=?1 AND track_key=?2 AND role=?3
                AND language=?4 AND script=?5 AND cache_input_digest=?6
-             ORDER BY CASE authority WHEN 'source' THEN 0 ELSE 1 END,updated_at DESC LIMIT 1",
+             ORDER BY CASE authority WHEN CASE WHEN ?7 THEN 'source' ELSE 'external' END THEN 0 ELSE 1 END,updated_at DESC LIMIT 1",
         )
         .bind(source)
         .bind(track)
@@ -70,6 +71,7 @@ impl Database {
         .bind(language)
         .bind(script)
         .bind(cache_input_digest.as_slice())
+        .bind(prefer_source)
         .fetch_optional(&mut *connection)
         .await;
         Database::clear_progress(&mut connection).await?;

--- a/crates/library/tests/services.rs
+++ b/crates/library/tests/services.rs
@@ -654,22 +654,14 @@ async fn local_mapping_selects_one_exact_or_representative_track_without_a_libra
         .expect("representative mapping Track")
         .pop()
         .expect("mapping Track");
-    let exact = fixture
+    let exact_path = fixture
         .database
-        .mapping_track_page(
-            fixture.source,
-            None,
-            Some(&representative.source_path),
-            1,
-            &cancel,
-        )
+        .mapping_track_source_path(fixture.source, representative.track_key, &cancel)
         .await
         .expect("exact mapping Track")
-        .pop()
         .expect("exact mapping Track");
 
-    assert_eq!(exact.track_key, representative.track_key);
-    assert_eq!(exact.object_id, representative.object_id);
+    assert_eq!(exact_path, representative.source_path);
 }
 
 #[tokio::test]
@@ -692,6 +684,21 @@ async fn lyrics_cache_identity_includes_input_digest_and_evicts_bounded_rows() {
         )
         .await
         .expect("write lyrics");
+    fixture
+        .database
+        .write_lyrics_cache(
+            fixture.source,
+            fixture.tracks[0],
+            "external",
+            "lyrics",
+            "en",
+            "Latn",
+            [1; 32],
+            "External",
+            20,
+        )
+        .await
+        .expect("write external lyrics");
     let row = fixture
         .database
         .lyrics_cache_for_role(
@@ -701,12 +708,29 @@ async fn lyrics_cache_identity_includes_input_digest_and_evicts_bounded_rows() {
             "en",
             "Latn",
             [1; 32],
+            true,
             &cancel,
         )
         .await
         .expect("read lyrics")
         .unwrap();
     assert_eq!(row.lyrics, "First");
+    let external = fixture
+        .database
+        .lyrics_cache_for_role(
+            fixture.source,
+            fixture.tracks[0],
+            "lyrics",
+            "en",
+            "Latn",
+            [1; 32],
+            false,
+            &cancel,
+        )
+        .await
+        .expect("read preferred external lyrics")
+        .unwrap();
+    assert_eq!(external.lyrics, "External");
     assert!(
         fixture
             .database
@@ -717,6 +741,7 @@ async fn lyrics_cache_identity_includes_input_digest_and_evicts_bounded_rows() {
                 "en",
                 "Latn",
                 [2; 32],
+                true,
                 &cancel
             )
             .await
@@ -748,6 +773,7 @@ async fn lyrics_cache_identity_includes_input_digest_and_evicts_bounded_rows() {
                 "",
                 "",
                 [2; 32],
+                true,
                 &cancel
             )
             .await

--- a/crates/lyrics/src/current.rs
+++ b/crates/lyrics/src/current.rs
@@ -15,16 +15,17 @@ use tokio::task::JoinHandle;
 use tracing::{debug, warn};
 
 use crate::lyrics::{
-    LyricsPlan, cached_lyrics_allowed, external_best_lyrics, local_sidecar_lyrics,
-    lyrics_from_native, lyrics_with_displayable_content,
+    LyricsPlan, cached_lyrics_allowed, embedded_lyrics_from_audio, external_best_lyrics,
+    local_sidecar_lyrics, lyrics_from_edited_text, lyrics_from_native,
+    lyrics_with_displayable_content,
 };
 use crate::{
     CurrentLyrics, CurrentLyricsContent, LocalLyricsInput, LyricsBundle, LyricsDocument,
     LyricsEvent, LyricsOrigin, LyricsQuery, LyricsRole, LyricsSearchResult, Settings,
-    lyrics_from_search_result, save_current_lyrics, search_lyrics,
+    lyrics_from_search_result, lyrics_to_lrc_text, save_current_lyrics, search_lyrics,
 };
 
-const LYRICS_CACHE_PAYLOAD_VERSION: u32 = 3;
+const LYRICS_CACHE_PAYLOAD_VERSION: u32 = 4;
 
 #[derive(Clone)]
 pub struct LyricsContext {
@@ -89,6 +90,7 @@ struct CurrentDocument {
     request: u64,
     loading: bool,
     automatic_attempted: bool,
+    writable: bool,
 }
 
 #[derive(Clone)]
@@ -116,6 +118,21 @@ struct CurrentResolution {
     plan: LyricsPlan,
 }
 
+struct LyricsWriteTarget {
+    source: Arc<Source>,
+    database: Database,
+    source_key: SourceKey,
+    track_key: TrackKey,
+    content: String,
+    media_id: CurrentMediaId,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LyricsAuthority {
+    Source,
+    External,
+}
+
 #[derive(Deserialize, Serialize)]
 struct CachedBundle {
     version: u32,
@@ -129,6 +146,7 @@ pub struct LyricsService {
     state: Mutex<State>,
     next_request: AtomicU64,
     search_lane: Arc<Semaphore>,
+    write_lane: Arc<Semaphore>,
 }
 
 #[derive(Clone)]
@@ -158,6 +176,7 @@ impl LyricsService {
             }),
             next_request: AtomicU64::new(1),
             search_lane: Arc::new(Semaphore::new(1)),
+            write_lane: Arc::new(Semaphore::new(1)),
         })
     }
 
@@ -173,18 +192,23 @@ impl LyricsService {
             return;
         };
         let key = DocumentKey::for_context(&context);
-        let event = {
+        let (event, write_check) = {
             let mut state = self
                 .state
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             if let Some(current) = state.current.as_mut().filter(|current| current.key == key) {
                 let media_changed = current.context.media.id != context.media.id;
+                let write_target_changed =
+                    current.context.media.track.media_uri != context.media.track.media_uri;
+                let write_check =
+                    (media_changed || write_target_changed).then(|| (key.clone(), context.clone()));
                 current.context = context;
-                media_changed.then(|| current_event(current))
+                (media_changed.then(|| current_event(current)), write_check)
             } else {
                 cancel_current_work(&mut state);
                 let request = self.next_request.fetch_add(1, Ordering::AcqRel);
+                let write_check = (key.clone(), context.clone());
                 let current = CurrentDocument {
                     context,
                     key,
@@ -194,15 +218,62 @@ impl LyricsService {
                     request,
                     loading: false,
                     automatic_attempted: false,
+                    writable: false,
                 };
                 let event = Some(current_event(&current));
                 state.current = Some(current);
                 state.search = None;
-                event
+                (event, Some(write_check))
             }
         };
         if let Some(event) = event {
             self.publish(event);
+        }
+        if let Some((key, context)) = write_check {
+            self.check_write_access(key, context);
+        }
+    }
+
+    fn check_write_access(self: &Arc<Self>, key: DocumentKey, context: LyricsContext) {
+        let service = Arc::clone(self);
+        self.runtime.spawn(async move {
+            let writable = match (context.source.as_ref(), key.track_key) {
+                (Some(source), Some(track)) => {
+                    source
+                        .lyrics_writable(&context.database, key.source_key, track)
+                        .await
+                }
+                _ => false,
+            };
+            let event = {
+                let mut state = service
+                    .state
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                let Some(current) = state.current.as_mut().filter(|current| current.key == key)
+                else {
+                    return;
+                };
+                if current.writable == writable {
+                    return;
+                }
+                current.writable = writable;
+                current_event(current)
+            };
+            service.publish(event);
+        });
+    }
+
+    fn refresh_write_access(self: &Arc<Self>) {
+        let current = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .current
+            .as_ref()
+            .map(|current| (current.key.clone(), current.context.clone()));
+        if let Some((key, context)) = current {
+            self.check_write_access(key, context);
         }
     }
 
@@ -219,13 +290,18 @@ impl LyricsService {
                     current.automatic_attempted || current.loading || current.bundle.is_some(),
                     current.loading,
                     current.bundle.is_some(),
+                    current
+                        .document
+                        .as_deref()
+                        .is_some_and(LyricsDocument::has_word_timing),
                 )
             });
             let selection_changed = lyrics_selection_changed(&state.settings, &settings);
+            let karaoke_enabled = !state.settings.karaoke_mode && settings.karaoke_mode;
             let acquisition_changed = current.as_ref().is_some_and(|(_, track_id, ..)| {
                 lyrics_acquisition_changed(&state.settings, &settings, track_id)
             });
-            let settings_changed = selection_changed || acquisition_changed;
+            let settings_changed = selection_changed || acquisition_changed || karaoke_enabled;
             let private_changed = state.private_mode != private_mode;
             state.settings = settings;
             state.private_mode = private_mode;
@@ -233,11 +309,14 @@ impl LyricsService {
                 return;
             }
             state.search = None;
-            let Some((media_id, track_id, attempted, loading, has_document)) = current else {
+            let Some((media_id, track_id, attempted, loading, has_document, has_word_timing)) =
+                current
+            else {
                 return;
             };
             let restart = attempted
                 && (selection_changed
+                    || karaoke_enabled && !has_word_timing
                     || acquisition_changed && (loading || !has_document)
                     || private_changed && (loading || !private_mode && !has_document));
             if !restart {
@@ -250,7 +329,9 @@ impl LyricsService {
                 .map(|prepared| {
                     (
                         prepared,
-                        selection_changed || (!settings_changed && !private_mode),
+                        selection_changed
+                            || karaoke_enabled
+                            || (!settings_changed && !private_mode),
                     )
                 })
         };
@@ -419,39 +500,51 @@ impl LyricsService {
         cancelled: Arc<AtomicBool>,
         use_cache: bool,
     ) {
-        let settings = Settings {
-            prefer_translations: resolution.plan.prefers_translations(),
-            preferred_translation_language: resolution
-                .plan
-                .preferred_translation_language()
-                .to_string(),
-            ..Settings::default()
-        };
         let mut fallback = None;
+        if !resolution.cue_track
+            && let Some(input) = resolution.local.as_ref()
+        {
+            let path = input.audio_path.clone();
+            let document = tokio::task::spawn_blocking(move || embedded_lyrics_from_audio(&path))
+                .await
+                .ok()
+                .flatten();
+            if let Some(document) = document
+                && self
+                    .resolve_candidate(
+                        request,
+                        &key,
+                        &resolution,
+                        &cancelled,
+                        &mut fallback,
+                        document,
+                    )
+                    .await
+            {
+                return;
+            }
+        }
+        if !self.current_request_active(request, &key, &cancelled) {
+            return;
+        }
         if let Some(input) = resolution.local.take() {
             let document = tokio::task::spawn_blocking(move || local_sidecar_lyrics(&input))
                 .await
                 .ok()
                 .flatten();
-            if let Some(document) = document {
-                if document.is_instrumental()
-                    || (!resolution.plan.prefers_translations() && document.has_original())
-                    || document.has_preferred_translation(&settings)
-                {
-                    if self.current_request_active(request, &key, &cancelled) {
-                        self.cache_and_accept(
-                            request,
-                            &key,
-                            &resolution.input,
-                            &resolution.plan,
-                            document,
-                        )
-                        .await;
-                    }
-                    return;
-                } else {
-                    fallback = Some(document);
-                }
+            if let Some(document) = document
+                && self
+                    .resolve_candidate(
+                        request,
+                        &key,
+                        &resolution,
+                        &cancelled,
+                        &mut fallback,
+                        document,
+                    )
+                    .await
+            {
+                return;
             }
         }
         if !self.current_request_active(request, &key, &cancelled) {
@@ -470,6 +563,7 @@ impl LyricsService {
                         &language,
                         &script,
                         resolution.input.digest,
+                        resolution.plan.prefers_server(),
                         &cancellation,
                     )
                     .await
@@ -480,69 +574,37 @@ impl LyricsService {
             };
             if let Some(cached) = cached {
                 let authority = cached.authority.clone();
-                if let Some(document) = cached_bundle(&cached)
+                let candidate = cached_bundle(&cached)
                     .and_then(lyrics_with_displayable_content)
                     .filter(|document| {
                         cached_lyrics_allowed(document, &resolution.plan, resolution.cue_track)
-                            && bundle_satisfies_plan(document, &resolution.plan)
-                    })
-                {
-                    self.accept_bundle(request, &key, Arc::new(document));
-                    return;
-                }
-                if !self.current_request_active(request, &key, &cancelled) {
-                    return;
-                }
-                if let Some(track_key) = key.track_key {
-                    let (role, language, script) = key.cache_key(&resolution.plan);
-                    let _ = self
-                        .database
-                        .remove_lyrics_cache(
-                            key.source_key,
-                            track_key,
-                            &authority,
-                            &role,
-                            &language,
-                            &script,
-                        )
-                        .await;
-                }
-            }
-        }
-        if !self.current_request_active(request, &key, &cancelled) {
-            return;
-        }
-
-        if let Some(source) = resolution.source.take() {
-            match source
-                .lyrics(&key.track_object_id, resolution.plan.native_search())
-                .await
-            {
-                Ok(Some(native)) => {
-                    let document = lyrics_from_native(native);
-                    if document.is_instrumental()
-                        || (!resolution.plan.prefers_translations() && document.has_original())
-                        || document.has_preferred_translation(&settings)
-                    {
-                        if self.current_request_active(request, &key, &cancelled) {
-                            self.cache_and_accept(
-                                request,
-                                &key,
-                                &resolution.input,
-                                &resolution.plan,
-                                document,
-                            )
-                            .await;
-                        }
+                    });
+                if let Some(document) = candidate {
+                    if acquisition_complete(&document, &resolution.plan) {
+                        self.accept_bundle(request, &key, Arc::new(document));
                         return;
                     }
-                    if fallback.is_none() && document.has_original() {
-                        fallback = Some(document);
+                    if prefer_fallback(&mut fallback, document, &resolution.plan) {
+                        self.show_fallback(request, &key, fallback.as_ref().expect("fallback"));
                     }
-                }
-                Ok(None) => {}
-                Err(error) => {
-                    debug!(%error, track_id = %key.track_object_id, "native lyrics request failed");
+                } else {
+                    if !self.current_request_active(request, &key, &cancelled) {
+                        return;
+                    }
+                    if let Some(track_key) = key.track_key {
+                        let (role, language, script) = key.cache_key(&resolution.plan);
+                        let _ = self
+                            .database
+                            .remove_lyrics_cache(
+                                key.source_key,
+                                track_key,
+                                &authority,
+                                &role,
+                                &language,
+                                &script,
+                            )
+                            .await;
+                    }
                 }
             }
         }
@@ -550,55 +612,47 @@ impl LyricsService {
             return;
         }
 
-        if resolution.plan.allows_external_fallback() {
-            let track = resolution.track;
-            let providers = resolution.plan.external_providers().to_vec();
-            let prefer_translations = resolution.plan.prefers_translations();
-            let preferred_translation_language =
-                resolution.plan.preferred_translation_language().to_string();
-            let lookup_cancelled = Arc::clone(&cancelled);
-            let document = run_external_lookup(Arc::clone(&self.search_lane), move || {
-                external_best_lyrics(
-                    &track,
-                    &providers,
-                    prefer_translations,
-                    &preferred_translation_language,
-                    &lookup_cancelled,
-                )
-            })
-            .await
-            .and_then(|result| match result {
-                Ok(document) => document,
-                Err(error) => {
-                    debug!(%error, "external lyrics request failed");
-                    None
+        for authority in acquisition_order(resolution.plan.prefers_server()) {
+            let complete = match authority {
+                LyricsAuthority::Source => {
+                    self.resolve_source_candidate(
+                        request,
+                        &key,
+                        &resolution,
+                        &cancelled,
+                        &mut fallback,
+                    )
+                    .await
                 }
-            });
-            if let Some(document) = document {
-                let selected = document.is_instrumental()
-                    || (!resolution.plan.prefers_translations() && document.has_original())
-                    || document.has_preferred_translation(&settings);
-                if selected {
-                    if self.current_request_active(request, &key, &cancelled) {
-                        self.cache_and_accept(
-                            request,
-                            &key,
-                            &resolution.input,
-                            &resolution.plan,
-                            document,
-                        )
-                        .await;
-                    }
-                    return;
+                LyricsAuthority::External => {
+                    self.resolve_external_candidate(
+                        request,
+                        &key,
+                        &resolution,
+                        &cancelled,
+                        &mut fallback,
+                    )
+                    .await
                 }
-                if fallback.is_none() && document.has_original() {
-                    fallback = Some(document);
-                }
+            };
+            if complete || !self.current_request_active(request, &key, &cancelled) {
+                return;
             }
         }
         if let Some(document) = fallback {
             if self.current_request_active(request, &key, &cancelled) {
-                self.accept_bundle(request, &key, Arc::new(document));
+                if matches!(document.origin, LyricsOrigin::External(_)) {
+                    self.cache_and_accept(
+                        request,
+                        &key,
+                        &resolution.input,
+                        &resolution.plan,
+                        document,
+                    )
+                    .await;
+                } else {
+                    self.accept_bundle(request, &key, Arc::new(document));
+                }
             }
             return;
         }
@@ -607,8 +661,113 @@ impl LyricsService {
         }
     }
 
+    async fn resolve_source_candidate(
+        self: &Arc<Self>,
+        request: u64,
+        key: &DocumentKey,
+        resolution: &CurrentResolution,
+        cancelled: &AtomicBool,
+        fallback: &mut Option<LyricsBundle>,
+    ) -> bool {
+        let Some(source) = resolution.source.as_ref() else {
+            return false;
+        };
+        match source.lyrics(&key.track_object_id).await {
+            Ok(Some(native)) => {
+                self.resolve_candidate(
+                    request,
+                    key,
+                    resolution,
+                    cancelled,
+                    fallback,
+                    lyrics_from_native(native),
+                )
+                .await
+            }
+            Ok(None) => false,
+            Err(error) => {
+                debug!(%error, track_id = %key.track_object_id, "source lyrics request failed");
+                false
+            }
+        }
+    }
+
+    async fn resolve_external_candidate(
+        self: &Arc<Self>,
+        request: u64,
+        key: &DocumentKey,
+        resolution: &CurrentResolution,
+        cancelled: &Arc<AtomicBool>,
+        fallback: &mut Option<LyricsBundle>,
+    ) -> bool {
+        if !resolution.plan.allows_external_fallback() {
+            return false;
+        }
+        let track = resolution.track.clone();
+        let providers = resolution.plan.external_providers().to_vec();
+        let require_word_timing = resolution.plan.requires_word_timing();
+        let prefer_translations = resolution.plan.prefers_translations();
+        let preferred_translation_language =
+            resolution.plan.preferred_translation_language().to_string();
+        let lookup_cancelled = Arc::clone(cancelled);
+        let document = run_external_lookup(Arc::clone(&self.search_lane), move || {
+            external_best_lyrics(
+                &track,
+                &providers,
+                require_word_timing,
+                prefer_translations,
+                &preferred_translation_language,
+                &lookup_cancelled,
+            )
+        })
+        .await
+        .and_then(|result| match result {
+            Ok(document) => document,
+            Err(error) => {
+                debug!(%error, "external lyrics request failed");
+                None
+            }
+        });
+        let Some(document) = document else {
+            return false;
+        };
+        if acquisition_complete(&document, &resolution.plan) {
+            if self.current_request_active(request, key, cancelled) {
+                self.cache_and_accept(request, key, &resolution.input, &resolution.plan, document)
+                    .await;
+            }
+            return true;
+        }
+        if prefer_fallback(fallback, document, &resolution.plan) {
+            self.show_fallback(request, key, fallback.as_ref().expect("fallback"));
+        }
+        false
+    }
+
+    async fn resolve_candidate(
+        self: &Arc<Self>,
+        request: u64,
+        key: &DocumentKey,
+        resolution: &CurrentResolution,
+        cancelled: &AtomicBool,
+        fallback: &mut Option<LyricsBundle>,
+        document: LyricsBundle,
+    ) -> bool {
+        if acquisition_complete(&document, &resolution.plan) {
+            if self.current_request_active(request, key, cancelled) {
+                self.cache_and_accept(request, key, &resolution.input, &resolution.plan, document)
+                    .await;
+            }
+            return true;
+        }
+        if prefer_fallback(fallback, document, &resolution.plan) {
+            self.show_fallback(request, key, fallback.as_ref().expect("fallback"));
+        }
+        false
+    }
+
     async fn cache_and_accept(
-        &self,
+        self: &Arc<Self>,
         request: u64,
         key: &DocumentKey,
         input: &SourceInputIdentity,
@@ -618,6 +777,9 @@ impl LyricsService {
         if !self.matches_current(request, key) {
             return;
         }
+        let write_target = matches!(document.origin, LyricsOrigin::External(_))
+            .then(|| self.fetched_lyrics_write_target(request, key, &document))
+            .flatten();
         match cache_write(key, plan, &document) {
             Ok((authority, role, language, script, payload, updated_at)) => {
                 if let Some(track_key) = key.track_key
@@ -642,10 +804,108 @@ impl LyricsService {
             Err(error) => warn!(%error, "could not encode lyrics cache"),
         }
         self.accept_bundle(request, key, Arc::new(document));
+        if let Some(target) = write_target {
+            self.queue_fetched_lyrics_write(target);
+        }
+    }
+
+    fn fetched_lyrics_write_target(
+        &self,
+        request: u64,
+        key: &DocumentKey,
+        lyrics: &LyricsBundle,
+    ) -> Option<LyricsWriteTarget> {
+        {
+            let state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let Some(current) = state
+                .current
+                .as_ref()
+                .filter(|current| current.request == request && &current.key == key)
+            else {
+                return None;
+            };
+            if !state.settings.save_fetched_lyrics {
+                return None;
+            }
+            let (Some(source), Some(track_key)) = (current.context.source.clone(), key.track_key)
+            else {
+                return None;
+            };
+            let Some(document) = lyrics.selected_document(&state.settings) else {
+                return None;
+            };
+            Some(LyricsWriteTarget {
+                source,
+                database: current.context.database.clone(),
+                source_key: key.source_key,
+                track_key,
+                content: lyrics_to_lrc_text(document, 0),
+                media_id: current.context.media.id.clone(),
+            })
+        }
+    }
+
+    async fn write_fetched_lyrics(&self, target: LyricsWriteTarget) {
+        let Ok(_permit) = self.write_lane.acquire().await else {
+            return;
+        };
+        if let Err(error) = target
+            .source
+            .write_lyrics(
+                &target.database,
+                target.source_key,
+                target.track_key,
+                &target.content,
+            )
+            .await
+        {
+            warn!(%error, "could not save fetched lyrics");
+            self.publish(LyricsEvent::SourceSaveFailed {
+                media_id: target.media_id,
+                error,
+            });
+        }
+    }
+
+    fn queue_fetched_lyrics_write(self: &Arc<Self>, target: LyricsWriteTarget) {
+        let service = Arc::clone(self);
+        self.runtime.spawn(async move {
+            service.write_fetched_lyrics(target).await;
+        });
     }
 
     fn accept_bundle(&self, request: u64, key: &DocumentKey, bundle: Arc<LyricsBundle>) {
         self.finish_current(request, key, Some(bundle));
+    }
+
+    fn show_fallback(&self, request: u64, key: &DocumentKey, bundle: &LyricsBundle) {
+        let event = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let settings = state.settings.clone();
+            let Some(current) = state
+                .current
+                .as_mut()
+                .filter(|current| current.request == request && &current.key == key)
+            else {
+                return;
+            };
+            if current
+                .bundle
+                .as_deref()
+                .is_some_and(|visible| visible == bundle)
+            {
+                return;
+            }
+            apply_bundle(current, &settings, Arc::new(bundle.clone()));
+            current_event(current)
+        };
+        self.publish(event);
     }
 
     fn finish_current(&self, request: u64, key: &DocumentKey, bundle: Option<Arc<LyricsBundle>>) {
@@ -664,13 +924,7 @@ impl LyricsService {
             };
             current.loading = false;
             if let Some(bundle) = bundle {
-                let selected = bundle.selected_document(&settings);
-                current.pronunciation = selected
-                    .and_then(|document| bundle.pronunciation_for(document))
-                    .cloned()
-                    .map(Arc::new);
-                current.document = selected.cloned().map(Arc::new);
-                current.bundle = Some(bundle);
+                apply_bundle(current, &settings, bundle);
             } else if current.bundle.is_none() {
                 current.pronunciation = None;
                 current.bundle = None;
@@ -880,9 +1134,14 @@ impl LyricsService {
                             )
                             .await;
                     }
+                    let write_target =
+                        service.fetched_lyrics_write_target(request, &key, &document);
                     let accepted = service.matches_current(request, &key);
                     if accepted {
                         service.accept_bundle(request, &key, Arc::clone(&document));
+                    }
+                    if let Some(target) = write_target {
+                        service.queue_fetched_lyrics_write(target);
                     }
                     service.publish(LyricsEvent::Saved { media_id, path });
                 }
@@ -972,6 +1231,74 @@ impl LyricsService {
         });
     }
 
+    fn update_lyrics_text(self: &Arc<Self>, media_id: CurrentMediaId, text: String) {
+        let Some(bundle) = lyrics_from_edited_text(&text) else {
+            return;
+        };
+        let Some(document) = bundle.documents().first() else {
+            return;
+        };
+        let prepared = {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let Some(current) = state
+                .current
+                .as_ref()
+                .filter(|current| current.context.media.id == media_id)
+            else {
+                return;
+            };
+            let (Some(source), Some(track_key)) =
+                (current.context.source.clone(), current.key.track_key)
+            else {
+                return;
+            };
+            let key = current.key.clone();
+            let input = current.context.input.clone();
+            let database = current.context.database.clone();
+            let plan = state
+                .settings
+                .configured_lyrics_plan(state.private_mode, &key.track_object_id);
+            cancel_current_work(&mut state);
+            let request = self.next_request.fetch_add(1, Ordering::AcqRel);
+            if let Some(current) = state.current.as_mut() {
+                current.request = request;
+                current.loading = false;
+            }
+            (request, key, input, plan, source, database, track_key)
+        };
+        let service = Arc::clone(self);
+        let (request, key, input, plan, source, database, track_key) = prepared;
+        let content = lyrics_to_lrc_text(document, 0);
+        let _task = self.runtime.spawn(async move {
+            let Ok(_permit) = service.write_lane.acquire().await else {
+                return;
+            };
+            match source
+                .write_lyrics(&database, key.source_key, track_key, &content)
+                .await
+            {
+                Ok(()) => match source.refresh_written_lyrics().await {
+                    Ok(()) => {
+                        service
+                            .cache_and_accept(request, &key, &input, &plan, bundle)
+                            .await;
+                    }
+                    Err(error) => {
+                        warn!(%error, "could not refresh edited lyrics source");
+                        service.publish(LyricsEvent::SourceSaveFailed { media_id, error });
+                    }
+                },
+                Err(error) => {
+                    warn!(%error, "could not save edited lyrics");
+                    service.publish(LyricsEvent::SourceSaveFailed { media_id, error });
+                }
+            }
+        });
+    }
+
     fn clear_fetched(self: &Arc<Self>, media_id: CurrentMediaId) {
         let key = {
             let state = self
@@ -1027,6 +1354,24 @@ impl LyricsHandle {
         self.service.save_current(media_id, offset_millis, path);
     }
 
+    pub fn update_lyrics_text(&self, media_id: CurrentMediaId, text: String) {
+        self.service.update_lyrics_text(media_id, text);
+    }
+
+    pub fn current_writable(&self, media_id: &CurrentMediaId) -> bool {
+        self.service
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .current
+            .as_ref()
+            .is_some_and(|current| &current.context.media.id == media_id && current.writable)
+    }
+
+    pub fn refresh_write_access(&self) {
+        self.service.refresh_write_access();
+    }
+
     pub fn clear_fetched(&self, media_id: CurrentMediaId) {
         self.service.clear_fetched(media_id);
     }
@@ -1058,6 +1403,16 @@ fn current_event(current: &CurrentDocument) -> LyricsEvent {
     }
 }
 
+fn apply_bundle(current: &mut CurrentDocument, settings: &Settings, bundle: Arc<LyricsBundle>) {
+    let selected = bundle.selected_document(settings);
+    current.pronunciation = selected
+        .and_then(|document| bundle.pronunciation_for(document))
+        .cloned()
+        .map(Arc::new);
+    current.document = selected.cloned().map(Arc::new);
+    current.bundle = Some(bundle);
+}
+
 fn selection_settings(plan: &LyricsPlan) -> Settings {
     Settings {
         prefer_translations: plan.prefers_translations(),
@@ -1076,6 +1431,29 @@ fn bundle_satisfies_plan(bundle: &LyricsBundle, plan: &LyricsPlan) -> bool {
     }
 }
 
+fn acquisition_complete(bundle: &LyricsBundle, plan: &LyricsPlan) -> bool {
+    bundle.is_instrumental()
+        || bundle_satisfies_plan(bundle, plan)
+            && (!plan.requires_word_timing()
+                || bundle
+                    .selected_document(&selection_settings(plan))
+                    .is_some_and(LyricsDocument::has_word_timing))
+}
+
+fn prefer_fallback(
+    fallback: &mut Option<LyricsBundle>,
+    candidate: LyricsBundle,
+    plan: &LyricsPlan,
+) -> bool {
+    let replace = fallback.as_ref().is_none_or(|current| {
+        !bundle_satisfies_plan(current, plan) && bundle_satisfies_plan(&candidate, plan)
+    });
+    if replace {
+        *fallback = Some(candidate);
+    }
+    replace
+}
+
 fn cache_key_for_bundle(
     key: &DocumentKey,
     plan: &LyricsPlan,
@@ -1091,6 +1469,14 @@ fn cache_key_for_bundle(
 fn lyrics_selection_changed(previous: &Settings, current: &Settings) -> bool {
     previous.prefer_translations != current.prefer_translations
         || previous.preferred_translation_language != current.preferred_translation_language
+}
+
+fn acquisition_order(prefer_server: bool) -> [LyricsAuthority; 2] {
+    if prefer_server {
+        [LyricsAuthority::Source, LyricsAuthority::External]
+    } else {
+        [LyricsAuthority::External, LyricsAuthority::Source]
+    }
 }
 
 fn lyrics_acquisition_changed(previous: &Settings, current: &Settings, track_id: &str) -> bool {
@@ -1128,17 +1514,11 @@ async fn run_external_lookup(
 
 fn current_resolution(context: LyricsContext, plan: LyricsPlan) -> CurrentResolution {
     let cue_track = context.media.track.cue_path.is_some();
-    let local = context
-        .media
-        .track
-        .media_uri
-        .as_deref()
-        .and_then(|uri| uri.strip_prefix("file://"))
-        .map(|path| LocalLyricsInput {
-            audio_path: PathBuf::from(path),
-            title: context.media.track.title.clone(),
-            cue_track,
-        });
+    let local = local_audio_path(&context.media.track).map(|path| LocalLyricsInput {
+        audio_path: path,
+        title: context.media.track.title.clone(),
+        cue_track,
+    });
     CurrentResolution {
         input: context.input,
         source: context.source,
@@ -1147,6 +1527,14 @@ fn current_resolution(context: LyricsContext, plan: LyricsPlan) -> CurrentResolu
         cue_track,
         plan,
     }
+}
+
+fn local_audio_path(track: &PlaybackMedia) -> Option<PathBuf> {
+    track
+        .media_uri
+        .as_deref()
+        .and_then(|uri| uri.strip_prefix("file://"))
+        .map(PathBuf::from)
 }
 
 fn cached_bundle(cached: &library::LyricsCacheRow) -> Option<LyricsBundle> {
@@ -1186,4 +1574,101 @@ fn unix_seconds() -> i64 {
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_secs().min(i64::MAX as u64) as i64)
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{LyricsCue, LyricsCueLine, LyricsLine};
+
+    #[test]
+    fn server_preference_owns_source_and_external_order() {
+        assert_eq!(
+            acquisition_order(true),
+            [LyricsAuthority::Source, LyricsAuthority::External],
+        );
+        assert_eq!(
+            acquisition_order(false),
+            [LyricsAuthority::External, LyricsAuthority::Source],
+        );
+    }
+
+    #[test]
+    fn karaoke_requires_word_timing_for_every_lyrics_origin() {
+        let plan = Settings {
+            karaoke_mode: true,
+            ..Settings::default()
+        }
+        .automatic_lyrics_plan(false, "track");
+        for origin in [
+            LyricsOrigin::Local,
+            LyricsOrigin::Native,
+            LyricsOrigin::External(crate::ExternalLyricsProvider::Lrclib),
+        ] {
+            assert!(!acquisition_complete(&bundle(origin, false), &plan));
+            assert!(acquisition_complete(&bundle(origin, true), &plan));
+        }
+    }
+
+    #[test]
+    fn ordinary_lyrics_complete_acquisition_while_karaoke_is_off() {
+        let plan = Settings::default().automatic_lyrics_plan(false, "track");
+
+        assert!(acquisition_complete(
+            &bundle(LyricsOrigin::Local, false),
+            &plan,
+        ));
+    }
+
+    #[test]
+    fn regular_external_lyrics_do_not_replace_an_existing_local_fallback() {
+        let plan = Settings::default().automatic_lyrics_plan(false, "track");
+        let mut fallback = Some(bundle(LyricsOrigin::Local, false));
+
+        assert!(!prefer_fallback(
+            &mut fallback,
+            bundle(
+                LyricsOrigin::External(crate::ExternalLyricsProvider::Lrclib),
+                false,
+            ),
+            &plan,
+        ));
+        assert_eq!(fallback.expect("fallback").origin, LyricsOrigin::Local);
+    }
+
+    fn bundle(origin: LyricsOrigin, word_timed: bool) -> LyricsBundle {
+        let text = "A line".to_string();
+        let cue_lines = word_timed
+            .then(|| {
+                vec![LyricsCueLine {
+                    text: text.clone(),
+                    start_millis: Some(1_000),
+                    end_millis: Some(2_000),
+                    agent_id: None,
+                    cues: vec![LyricsCue {
+                        text: text.clone(),
+                        start_millis: 1_000,
+                        end_millis: Some(2_000),
+                        byte_start: 0,
+                        byte_end_exclusive: text.len(),
+                    }],
+                }]
+            })
+            .unwrap_or_default();
+        LyricsBundle::from_documents(
+            origin,
+            vec![LyricsDocument {
+                role: LyricsRole::Original,
+                language: None,
+                offset_millis: 0,
+                lines: vec![LyricsLine {
+                    text,
+                    start_millis: Some(1_000),
+                    end_millis: Some(2_000),
+                    cue_lines,
+                }],
+                agents: Vec::new(),
+            }],
+        )
+    }
 }

--- a/crates/lyrics/src/events.rs
+++ b/crates/lyrics/src/events.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use playback::CurrentMediaId;
+use sources::SourceMetadataError;
 
 use crate::{LyricsDocument, LyricsOrigin, LyricsQuery, LyricsSearchResult};
 
@@ -44,5 +45,9 @@ pub enum LyricsEvent {
     Saved {
         media_id: CurrentMediaId,
         path: PathBuf,
+    },
+    SourceSaveFailed {
+        media_id: CurrentMediaId,
+        error: SourceMetadataError,
     },
 }

--- a/crates/lyrics/src/lib.rs
+++ b/crates/lyrics/src/lib.rs
@@ -12,8 +12,8 @@ mod lyrics;
 pub use current::{LyricsContext, LyricsHandle, LyricsService};
 pub use events::{CurrentLyrics, CurrentLyricsContent, LyricsEvent};
 pub use lyrics::{
-    LocalLyricsInput, lyrics_from_search_result, save_current_lyrics, save_lyrics_search_result,
-    search_lyrics,
+    LocalLyricsInput, lyrics_from_search_result, lyrics_to_lrc_text, save_current_lyrics,
+    save_lyrics_search_result, search_lyrics, shift_lrc_text_timestamps,
 };
 
 pub const LYRICS_PROVIDER_SETTINGS_VERSION: u8 = 1;
@@ -79,6 +79,8 @@ pub struct Settings {
     #[serde(default = "default_true")]
     pub prefer_server_lyrics: bool,
     #[serde(default)]
+    pub save_fetched_lyrics: bool,
+    #[serde(default)]
     pub lyrics_provider_settings_version: u8,
     #[serde(default)]
     pub suppressed_auto_lyrics_track_ids: Vec<String>,
@@ -90,8 +92,14 @@ pub struct Settings {
     pub show_furigana: bool,
     #[serde(default)]
     pub show_romanization: bool,
-    #[serde(default = "default_true")]
-    pub word_by_word_highlighting: bool,
+    #[serde(default)]
+    pub karaoke_mode: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lyrics_font_family: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lyrics_font_size: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lyrics_highlight_color: Option<String>,
 }
 
 impl Default for Settings {
@@ -100,13 +108,17 @@ impl Default for Settings {
             external_lyrics_enabled: true,
             external_lyrics_providers: default_external_lyrics_providers(),
             prefer_server_lyrics: true,
+            save_fetched_lyrics: false,
             lyrics_provider_settings_version: LYRICS_PROVIDER_SETTINGS_VERSION,
             suppressed_auto_lyrics_track_ids: Vec::new(),
             prefer_translations: false,
             preferred_translation_language: default_translation_language(),
             show_furigana: false,
             show_romanization: false,
-            word_by_word_highlighting: true,
+            karaoke_mode: false,
+            lyrics_font_family: None,
+            lyrics_font_size: None,
+            lyrics_highlight_color: None,
         }
     }
 }
@@ -129,6 +141,19 @@ impl Settings {
         self.preferred_translation_language =
             normalize_language_tag(&self.preferred_translation_language)
                 .unwrap_or_else(default_translation_language);
+        self.lyrics_font_family = self
+            .lyrics_font_family
+            .take()
+            .map(|family| family.trim().chars().take(128).collect::<String>())
+            .filter(|family| !family.is_empty());
+        self.lyrics_font_size = self.lyrics_font_size.map(|size| size.clamp(12, 28));
+        if self
+            .lyrics_highlight_color
+            .as_deref()
+            .is_some_and(|color| !valid_lyrics_color(color))
+        {
+            self.lyrics_highlight_color = None;
+        }
     }
 
     pub(crate) const fn external_lyrics_network_allowed(&self, private_mode: bool) -> bool {
@@ -783,6 +808,15 @@ fn default_translation_language() -> String {
     "en".to_string()
 }
 
+fn valid_lyrics_color(color: &str) -> bool {
+    color.strip_prefix('#').is_some_and(|digits| {
+        matches!(digits.len(), 6 | 8)
+            && digits
+                .chars()
+                .all(|character| character.is_ascii_hexdigit())
+    })
+}
+
 pub fn normalize_language_tag(value: &str) -> Option<String> {
     let value = value.trim().replace('_', "-").to_ascii_lowercase();
     if value.is_empty() || matches!(value.as_str(), "und" | "xxx") {
@@ -833,12 +867,13 @@ mod tests {
     #[test]
     fn sparse_settings_preserve_flat_defaults_and_provider_order() {
         let mut settings = serde_json::from_str::<Settings>(
-            r#"{"external_lyrics_enabled":false,"external_lyrics_providers":["genius","genius","lrclib"]}"#,
+            r#"{"external_lyrics_enabled":false,"external_lyrics_providers":["genius","genius","lrclib"],"word_by_word_highlighting":true}"#,
         )
         .expect("settings");
         settings.sanitize();
 
         assert!(!settings.external_lyrics_enabled);
+        assert!(!settings.karaoke_mode);
         assert!(settings.prefer_server_lyrics);
         assert_eq!(
             settings.external_lyrics_providers,
@@ -847,6 +882,25 @@ mod tests {
                 ExternalLyricsProvider::Lrclib
             ]
         );
+    }
+
+    #[test]
+    fn lyrics_appearance_settings_are_bounded_and_css_safe() {
+        let mut settings = Settings {
+            lyrics_font_family: Some(format!("  {}  ", "x".repeat(200))),
+            lyrics_font_size: Some(100),
+            lyrics_highlight_color: Some("red; } * { color: red".to_string()),
+            ..Settings::default()
+        };
+
+        settings.sanitize();
+
+        assert_eq!(
+            settings.lyrics_font_family.as_deref().map(str::len),
+            Some(128)
+        );
+        assert_eq!(settings.lyrics_font_size, Some(28));
+        assert_eq!(settings.lyrics_highlight_color, None);
     }
 
     #[test]

--- a/crates/lyrics/src/lyrics.rs
+++ b/crates/lyrics/src/lyrics.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
@@ -17,23 +17,21 @@ use crate::{
 };
 
 const EXTERNAL_LYRICS_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+const EXTERNAL_LYRICS_FETCH_CANDIDATES_PER_PROVIDER: usize = 3;
 const LRCLIB_RESPONSE_MAX_BYTES: usize = 2 * 1024 * 1024;
 const LOCAL_LYRICS_MAX_BYTES: usize = 2 * 1024 * 1024;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct LyricsPlan {
-    native_search: sources::LyricsSearch,
     external_providers: Vec<ExternalLyricsProvider>,
     allow_external_fallback: bool,
+    prefer_server: bool,
+    require_word_timing: bool,
     prefer_translations: bool,
     preferred_translation_language: String,
 }
 
 impl LyricsPlan {
-    pub(crate) const fn native_search(&self) -> sources::LyricsSearch {
-        self.native_search
-    }
-
     pub(crate) fn external_providers(&self) -> &[ExternalLyricsProvider] {
         &self.external_providers
     }
@@ -42,8 +40,16 @@ impl LyricsPlan {
         self.allow_external_fallback
     }
 
+    pub(crate) const fn prefers_server(&self) -> bool {
+        self.prefer_server
+    }
+
     pub(crate) const fn prefers_translations(&self) -> bool {
         self.prefer_translations
+    }
+
+    pub(crate) const fn requires_word_timing(&self) -> bool {
+        self.require_word_timing
     }
 
     pub(crate) fn preferred_translation_language(&self) -> &str {
@@ -53,36 +59,24 @@ impl LyricsPlan {
 
 impl crate::Settings {
     pub(crate) fn automatic_lyrics_plan(&self, private_mode: bool, track_id: &str) -> LyricsPlan {
-        self.lyrics_plan(private_mode, track_id, false)
+        self.lyrics_plan(private_mode, track_id)
     }
 
     pub(crate) fn configured_lyrics_plan(&self, private_mode: bool, track_id: &str) -> LyricsPlan {
-        self.lyrics_plan(private_mode, track_id, true)
+        self.lyrics_plan(private_mode, track_id)
     }
 
-    fn lyrics_plan(
-        &self,
-        private_mode: bool,
-        track_id: &str,
-        configured_native_order: bool,
-    ) -> LyricsPlan {
+    fn lyrics_plan(&self, private_mode: bool, track_id: &str) -> LyricsPlan {
         let external_enabled =
             self.external_lyrics_enabled && !self.auto_lyrics_suppressed(track_id);
         let external_network = external_enabled && !private_mode;
-        let native_search =
-            if configured_native_order && external_network && self.prefer_server_lyrics {
-                sources::LyricsSearch::ServerThenRemote
-            } else if configured_native_order && external_network {
-                sources::LyricsSearch::RemoteThenServer
-            } else {
-                sources::LyricsSearch::ServerOnly
-            };
         LyricsPlan {
-            native_search,
             external_providers: external_enabled
                 .then(|| self.external_lyrics_providers.clone())
                 .unwrap_or_default(),
             allow_external_fallback: external_network,
+            prefer_server: self.prefer_server_lyrics,
+            require_word_timing: self.karaoke_mode,
             prefer_translations: self.prefer_translations,
             preferred_translation_language: self.preferred_translation_language.clone(),
         }
@@ -220,12 +214,16 @@ pub(crate) fn cached_lyrics_allowed(lyrics: &Lyrics, plan: &LyricsPlan, cue_trac
     allowed && !(cue_track && lyrics.origin == LyricsOrigin::Local)
 }
 
-fn lyrics_from_text_content(provider: ExternalLyricsProvider, content: &str) -> Lyrics {
-    if content_marks_instrumental(content, Some(provider)) {
-        return Lyrics::instrumental(LyricsOrigin::External(provider));
+fn lyrics_from_text_content(origin: LyricsOrigin, content: &str) -> Lyrics {
+    let provider = match origin {
+        LyricsOrigin::External(provider) => Some(provider),
+        LyricsOrigin::Local | LyricsOrigin::Native => None,
+    };
+    if content_marks_instrumental(content, provider) {
+        return Lyrics::instrumental(origin);
     }
     Lyrics::from_documents(
-        LyricsOrigin::External(provider),
+        origin,
         vec![LyricsDocument {
             role: LyricsRole::Original,
             language: None,
@@ -233,7 +231,9 @@ fn lyrics_from_text_content(provider: ExternalLyricsProvider, content: &str) -> 
             lines: content
                 .lines()
                 .filter_map(lyric_line_from_text)
-                .filter(|line| provider_line_has_content(provider, line))
+                .filter(|line| {
+                    provider.is_none_or(|provider| provider_line_has_content(provider, line))
+                })
                 .collect(),
             agents: Vec::new(),
         }],
@@ -316,11 +316,12 @@ fn lyric_line_from_text(line: &str) -> Option<LyricLine> {
         return None;
     }
     if let Some((start_millis, text)) = parse_lrc_timestamp(trimmed) {
+        let (text, cue_lines) = parse_inline_cues(text, start_millis);
         return Some(LyricLine {
-            text: text.to_string(),
+            text,
             start_millis: Some(start_millis),
             end_millis: None,
-            cue_lines: Vec::new(),
+            cue_lines,
         });
     }
     if trimmed.starts_with('[') && trimmed.contains(']') {
@@ -336,20 +337,8 @@ fn lyric_line_from_text(line: &str) -> Option<LyricLine> {
 
 fn parse_lrc_timestamp(line: &str) -> Option<(u64, &str)> {
     let timestamp_end = line.find(']')?;
-    let timestamp = line.get(1..timestamp_end)?;
-    let (minutes, seconds) = timestamp.split_once(':')?;
-    let minutes = minutes.parse::<u64>().ok()?;
-    let (seconds, fraction) = seconds
-        .split_once('.')
-        .map(|(seconds, fraction)| (seconds, Some(fraction)))
-        .unwrap_or((seconds, None));
-    let seconds = seconds.parse::<u64>().ok()?;
-    let fraction_millis = match fraction {
-        Some(fraction) => fraction_to_millis(fraction)?,
-        None => 0,
-    };
     Some((
-        (minutes * 60 + seconds) * 1_000 + fraction_millis,
+        parse_lrc_time(line.get(1..timestamp_end)?)?,
         line.get(timestamp_end + 1..)?.trim(),
     ))
 }
@@ -366,6 +355,133 @@ fn fraction_to_millis(fraction: &str) -> Option<u64> {
             };
     }
     Some(millis)
+}
+
+fn parse_inline_cues(text: &str, line_start_millis: u64) -> (String, Vec<LyricsCueLine>) {
+    let stamps = text
+        .match_indices('<')
+        .filter_map(|(tag_start, _)| {
+            let rest = text.get(tag_start + 1..)?;
+            let close = rest.find('>')?;
+            let millis = parse_lrc_time(rest.get(..close)?)?;
+            Some((tag_start, tag_start + close + 2, millis))
+        })
+        .collect::<Vec<_>>();
+    let Some(first) = stamps.first() else {
+        return (text.to_string(), Vec::new());
+    };
+
+    let mut display = String::new();
+    let mut cues = Vec::new();
+    if let Some(prefix) = text.get(..first.0).filter(|prefix| !prefix.is_empty()) {
+        display.push_str(prefix);
+        cues.push(LyricsCue {
+            text: prefix.to_string(),
+            start_millis: line_start_millis,
+            end_millis: Some(first.2),
+            byte_start: 0,
+            byte_end_exclusive: display.len(),
+        });
+    }
+    for (index, (_, content_start, start_millis)) in stamps.iter().copied().enumerate() {
+        let content_end = stamps.get(index + 1).map_or(text.len(), |next| next.0);
+        let Some(content) = text
+            .get(content_start..content_end)
+            .filter(|content| !content.is_empty())
+        else {
+            continue;
+        };
+        let byte_start = display.len();
+        display.push_str(content);
+        cues.push(LyricsCue {
+            text: content.to_string(),
+            start_millis,
+            end_millis: stamps.get(index + 1).map(|next| next.2),
+            byte_start,
+            byte_end_exclusive: display.len(),
+        });
+    }
+    if cues.is_empty() {
+        return (text.to_string(), Vec::new());
+    }
+    (
+        display.clone(),
+        vec![LyricsCueLine {
+            text: display,
+            start_millis: Some(line_start_millis),
+            end_millis: cues.last().and_then(|cue| cue.end_millis),
+            agent_id: None,
+            cues,
+        }],
+    )
+}
+
+fn parse_lrc_time(timestamp: &str) -> Option<u64> {
+    let (minutes, seconds) = timestamp.split_once(':')?;
+    let minutes = minutes.parse::<u64>().ok()?;
+    let (seconds, fraction) = seconds
+        .split_once('.')
+        .map(|(seconds, fraction)| (seconds, Some(fraction)))
+        .unwrap_or((seconds, None));
+    let fraction_millis = match fraction {
+        Some(fraction) => fraction_to_millis(fraction)?,
+        None => 0,
+    };
+    Some((minutes * 60 + seconds.parse::<u64>().ok()?) * 1_000 + fraction_millis)
+}
+
+fn parse_yrc_line(line: &str) -> Option<LyricLine> {
+    let line = line.strip_prefix('[')?;
+    let (line_timing, mut words) = line.split_once(']')?;
+    let (line_start, line_duration) = parse_yrc_pair(line_timing)?;
+    let mut text = String::new();
+    let mut cues = Vec::new();
+    while let Some(stamp) = words.strip_prefix('(') {
+        let (timing, after_timing) = stamp.split_once(')')?;
+        let (start_millis, duration_millis) = parse_yrc_pair(timing)?;
+        let next_stamp = after_timing
+            .match_indices('(')
+            .find_map(|(index, _)| {
+                parse_yrc_word_stamp(after_timing.get(index..)?).then_some(index)
+            })
+            .unwrap_or(after_timing.len());
+        let word = after_timing.get(..next_stamp)?;
+        let byte_start = text.len();
+        text.push_str(word);
+        cues.push(LyricsCue {
+            text: word.to_string(),
+            start_millis,
+            end_millis: Some(start_millis.saturating_add(duration_millis)),
+            byte_start,
+            byte_end_exclusive: text.len(),
+        });
+        words = after_timing.get(next_stamp..)?;
+    }
+    (!cues.is_empty()).then(|| LyricLine {
+        text: text.clone(),
+        start_millis: Some(line_start),
+        end_millis: Some(line_start.saturating_add(line_duration)),
+        cue_lines: vec![LyricsCueLine {
+            text,
+            start_millis: Some(line_start),
+            end_millis: Some(line_start.saturating_add(line_duration)),
+            agent_id: None,
+            cues,
+        }],
+    })
+}
+
+fn parse_yrc_pair(value: &str) -> Option<(u64, u64)> {
+    let mut values = value.split(',');
+    Some((values.next()?.parse().ok()?, values.next()?.parse().ok()?))
+}
+
+fn parse_yrc_word_stamp(value: &str) -> bool {
+    value
+        .strip_prefix('(')
+        .and_then(|value| value.split_once(')'))
+        .and_then(|(timing, _)| parse_yrc_pair(timing))
+        .is_some()
 }
 
 fn inline_search_content(
@@ -465,6 +581,8 @@ struct NeteaseLyricsResponse {
     lrc: Option<NeteaseLyricsBody>,
     #[serde(default)]
     tlyric: Option<NeteaseLyricsBody>,
+    #[serde(default)]
+    yrc: Option<NeteaseLyricsBody>,
 }
 #[derive(Debug, Deserialize)]
 struct NeteaseLyricsBody {
@@ -701,6 +819,7 @@ pub fn search_lyrics(
 pub(crate) fn external_best_lyrics(
     track: &PlaybackMedia,
     providers: &[ExternalLyricsProvider],
+    require_word_timing: bool,
     prefer_translations: bool,
     preferred_translation_language: &str,
     cancelled: &AtomicBool,
@@ -763,20 +882,34 @@ pub(crate) fn external_best_lyrics(
         ..crate::Settings::default()
     };
     let mut fallback = None;
+    let mut fallback_satisfies_selection = false;
+    let mut deferred_attempts = HashMap::<ExternalLyricsProvider, usize>::new();
     for result in results {
         if cancelled.load(Ordering::Acquire) {
             return Ok(None);
         }
-        match lyrics_from_search_result(&result) {
-            Ok(Some(lyrics))
-                if lyrics.is_instrumental()
-                    || !prefer_translations
-                    || lyrics.has_preferred_translation(&selection) =>
-            {
-                return Ok(Some(lyrics));
+        if matches!(result.content, LyricsSearchContent::Deferred) {
+            let attempts = deferred_attempts.entry(result.provider).or_default();
+            if *attempts >= EXTERNAL_LYRICS_FETCH_CANDIDATES_PER_PROVIDER {
+                continue;
             }
+            *attempts += 1;
+        }
+        match lyrics_from_search_result(&result) {
+            Ok(Some(lyrics)) if lyrics.is_instrumental() => return Ok(Some(lyrics)),
             Ok(Some(lyrics)) => {
-                fallback.get_or_insert(lyrics);
+                let satisfies_selection =
+                    !prefer_translations || lyrics.has_preferred_translation(&selection);
+                let has_word_timing = lyrics
+                    .selected_document(&selection)
+                    .is_some_and(LyricsDocument::has_word_timing);
+                if satisfies_selection && (!require_word_timing || has_word_timing) {
+                    return Ok(Some(lyrics));
+                }
+                if fallback.is_none() || satisfies_selection && !fallback_satisfies_selection {
+                    fallback = Some(lyrics);
+                    fallback_satisfies_selection = satisfies_selection;
+                }
             }
             Ok(None) => {}
             Err(error) => errors.push(format!("{}: {error}", result.provider.title())),
@@ -1001,19 +1134,49 @@ fn lyrics_from_netease_response(response: NeteaseLyricsResponse) -> Option<Lyric
         )));
     }
     let mut documents = Vec::new();
-    for (role, language, body) in [
-        (LyricsRole::Original, None, response.lrc),
-        (LyricsRole::Translation, Some("zh"), response.tlyric),
-    ] {
-        let Some(content) = body
-            .and_then(|body| body.lyric)
-            .filter(|lyrics| !lyrics.trim().is_empty())
-        else {
-            continue;
-        };
+    let yrc_lines = response
+        .yrc
+        .and_then(|body| body.lyric)
+        .map(|content| {
+            content
+                .lines()
+                .filter_map(parse_yrc_line)
+                .filter(|line| provider_line_has_content(ExternalLyricsProvider::Netease, line))
+                .collect::<Vec<_>>()
+        })
+        .filter(|lines| !lines.is_empty());
+    debug!(
+        yrc_lines = yrc_lines.as_ref().map_or(0, Vec::len),
+        "parsed NetEase word timing"
+    );
+    let lrc = response.lrc.and_then(|body| body.lyric);
+    let original_lines = yrc_lines.or_else(|| {
+        lrc.filter(|lyrics| !lyrics.trim().is_empty())
+            .map(|content| {
+                content
+                    .lines()
+                    .filter_map(lyric_line_from_text)
+                    .filter(|line| provider_line_has_content(ExternalLyricsProvider::Netease, line))
+                    .collect::<Vec<_>>()
+            })
+    });
+    if let Some(lines) = original_lines.filter(|lines| !lines.is_empty()) {
         documents.push(LyricsDocument {
-            role,
-            language: language.map(str::to_string),
+            role: LyricsRole::Original,
+            language: None,
+            offset_millis: 0,
+            lines,
+            agents: Vec::new(),
+        });
+    }
+    if let Some(content) = response
+        .tlyric
+        .and_then(|body| body.lyric)
+        .filter(|lyrics| !lyrics.trim().is_empty())
+    {
+        documents.push(LyricsDocument {
+            role: LyricsRole::Translation,
+            language: Some("zh".to_string()),
             offset_millis: 0,
             lines: content
                 .lines()
@@ -1037,10 +1200,24 @@ fn netease_fetch_lyrics_response(id: &str) -> Result<NeteaseLyricsResponse, Stri
         pairs.append_pair("kv", "-1");
         pairs.append_pair("lv", "-1");
         pairs.append_pair("tv", "-1");
+        pairs.append_pair("yv", "-1");
     }
     let body = fetch_text(external_lyrics_client()?, url, "NetEase lyric lookup")?;
     let response = serde_json::from_str::<NeteaseLyricsResponse>(&body)
         .map_err(|error| format!("NetEase lyric lookup returned invalid data: {error}"))?;
+    debug!(
+        yrc_bytes = response
+            .yrc
+            .as_ref()
+            .and_then(|body| body.lyric.as_deref())
+            .map_or(0, str::len),
+        lrc_bytes = response
+            .lrc
+            .as_ref()
+            .and_then(|body| body.lyric.as_deref())
+            .map_or(0, str::len),
+        "received NetEase lyric payload"
+    );
     Ok(response)
 }
 fn genius_search(artist_name: &str, track_name: &str) -> Result<Vec<LyricsSearchResult>, String> {
@@ -1295,7 +1472,7 @@ pub fn lyrics_from_search_result(result: &LyricsSearchResult) -> Result<Option<L
     let Some(content) = content.filter(|lyrics| !lyrics.trim().is_empty()) else {
         return Ok(None);
     };
-    let lyrics = lyrics_from_text_content(result.provider, &content);
+    let lyrics = lyrics_from_text_content(LyricsOrigin::External(result.provider), &content);
     Ok(lyrics_with_displayable_content(lyrics))
 }
 fn external_fetch_lyrics(result: &LyricsSearchResult) -> Result<Option<String>, String> {
@@ -1674,50 +1851,122 @@ pub fn save_lyrics_search_result(
     result: &LyricsSearchResult,
     output_path: PathBuf,
 ) -> Result<Option<(PathBuf, Lyrics)>, String> {
-    let content = match lyrics_result_content(result) {
-        Some(content) => Some(content.to_string()),
-        None => external_fetch_lyrics(result)?,
-    }
-    .filter(|lyrics| !lyrics.trim().is_empty());
-    let Some(content) = content else {
+    let Some(lyrics) = lyrics_from_search_result(result)? else {
         return Ok(None);
     };
-    let lyrics = lyrics_from_text_content(result.provider, &content);
-    let Some(lyrics) = lyrics_with_displayable_content(lyrics) else {
+    let Some(document) = lyrics.selected_document(&crate::Settings::default()) else {
         return Ok(None);
     };
-    let path = output_path;
-    fs::write(&path, &content).map_err(|error| error.to_string())?;
-    debug!(path = %path.display(), "saved lyric file");
-    Ok(Some((path, lyrics)))
+    fs::write(&output_path, lyrics_to_lrc_text(document, 0)).map_err(|error| error.to_string())?;
+    debug!(path = %output_path.display(), "saved lyric file");
+    Ok(Some((output_path, lyrics)))
 }
 pub fn save_current_lyrics(
     lyrics: &LyricsDocument,
     offset_millis: i64,
     output_path: PathBuf,
 ) -> Result<PathBuf, String> {
-    let content = lyrics
-        .lines
-        .iter()
-        .map(|line| match line.start_millis {
-            Some(start_millis) => {
-                let start_millis = if offset_millis >= 0 {
-                    start_millis.saturating_sub(offset_millis.unsigned_abs())
-                } else {
-                    start_millis.saturating_add(offset_millis.unsigned_abs())
-                };
-                let minutes = start_millis / 60_000;
-                let seconds = start_millis % 60_000 / 1_000;
-                let millis = start_millis % 1_000;
-                format!("[{minutes:02}:{seconds:02}.{millis:03}]{}", line.text)
-            }
-            None => line.text.clone(),
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-    fs::write(&output_path, content).map_err(|error| error.to_string())?;
+    fs::write(&output_path, lyrics_to_lrc_text(lyrics, offset_millis))
+        .map_err(|error| error.to_string())?;
     debug!(path = %output_path.display(), "saved current lyric file");
     Ok(output_path)
+}
+
+pub fn lyrics_to_lrc_text(lyrics: &LyricsDocument, offset_millis: i64) -> String {
+    lyrics
+        .lines
+        .iter()
+        .map(|line| {
+            let inline = line
+                .cue_lines
+                .first()
+                .filter(|line| !line.cues.is_empty())
+                .and_then(|line| enhanced_lrc_text(line, offset_millis));
+            let start_millis = line
+                .start_millis
+                .or_else(|| line.cue_lines.first().and_then(|line| line.start_millis));
+            match (start_millis, inline) {
+                (Some(start), Some(inline)) => {
+                    format!("[{}]{inline}", lrc_timestamp(start, offset_millis))
+                }
+                (Some(start), None) => {
+                    format!("[{}]{}", lrc_timestamp(start, offset_millis), line.text)
+                }
+                (None, _) => line.text.clone(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub fn shift_lrc_text_timestamps(text: &str, offset_delta_millis: i64) -> String {
+    let mut output = String::with_capacity(text.len());
+    let mut cursor = 0;
+    while let Some((relative, open)) = text
+        .get(cursor..)
+        .unwrap_or_default()
+        .char_indices()
+        .find(|(_, character)| matches!(character, '[' | '<'))
+    {
+        let start = cursor + relative;
+        let close = if open == '[' { ']' } else { '>' };
+        let content_start = start + open.len_utf8();
+        let Some(relative_end) = text.get(content_start..).and_then(|text| text.find(close)) else {
+            break;
+        };
+        let end = content_start + relative_end;
+        let Some(content) = text.get(content_start..end) else {
+            break;
+        };
+        if content.contains('\n') {
+            output.push_str(text.get(cursor..content_start).unwrap_or_default());
+            cursor = content_start;
+            continue;
+        }
+        let Some(millis) = parse_lrc_time(content) else {
+            output.push_str(text.get(cursor..content_start).unwrap_or_default());
+            cursor = content_start;
+            continue;
+        };
+        output.push_str(text.get(cursor..content_start).unwrap_or_default());
+        output.push_str(&lrc_timestamp(millis, offset_delta_millis));
+        output.push(close);
+        cursor = end + close.len_utf8();
+    }
+    output.push_str(text.get(cursor..).unwrap_or_default());
+    output
+}
+
+fn enhanced_lrc_text(line: &LyricsCueLine, offset_millis: i64) -> Option<String> {
+    let mut output = String::new();
+    let mut cursor = 0;
+    for cue in &line.cues {
+        if cue.byte_start < cursor || cue.byte_end_exclusive < cue.byte_start {
+            return None;
+        }
+        output.push_str(line.text.get(cursor..cue.byte_start)?);
+        output.push('<');
+        output.push_str(&lrc_timestamp(cue.start_millis, offset_millis));
+        output.push('>');
+        output.push_str(line.text.get(cue.byte_start..cue.byte_end_exclusive)?);
+        cursor = cue.byte_end_exclusive;
+    }
+    output.push_str(line.text.get(cursor..)?);
+    Some(output)
+}
+
+fn lrc_timestamp(millis: u64, offset_millis: i64) -> String {
+    let millis = if offset_millis >= 0 {
+        millis.saturating_sub(offset_millis.unsigned_abs())
+    } else {
+        millis.saturating_add(offset_millis.unsigned_abs())
+    };
+    format!(
+        "{:02}:{:02}.{:03}",
+        millis / 60_000,
+        millis % 60_000 / 1_000,
+        millis % 1_000
+    )
 }
 pub(crate) fn lyrics_result_content(result: &LyricsSearchResult) -> Option<&str> {
     result
@@ -1746,27 +1995,26 @@ pub(crate) fn local_sidecar_lyrics(input: &LocalLyricsInput) -> Option<Lyrics> {
     }
     None
 }
+
+pub(crate) fn embedded_lyrics_from_audio(path: &Path) -> Option<Lyrics> {
+    let content = sources::read_embedded_lyrics(path).ok().flatten()?;
+    lyrics_from_local_text(&content)
+}
+
+pub(crate) fn lyrics_from_edited_text(content: &str) -> Option<Lyrics> {
+    lyrics_from_local_text(content)
+}
+
+fn lyrics_from_local_text(content: &str) -> Option<Lyrics> {
+    if content.len() > LOCAL_LYRICS_MAX_BYTES {
+        return None;
+    }
+    lyrics_with_displayable_content(lyrics_from_text_content(LyricsOrigin::Local, content))
+}
+
 fn lyrics_from_sidecar_file(path: &Path) -> Option<Lyrics> {
     let content = read_text_file_bounded(path, LOCAL_LYRICS_MAX_BYTES).ok()?;
-    if content_marks_instrumental(&content, None) {
-        return Some(Lyrics::instrumental(LyricsOrigin::Local));
-    }
-    let lines = content
-        .lines()
-        .filter_map(lyric_line_from_text)
-        .collect::<Vec<_>>();
-    (!lines.is_empty()).then(|| {
-        Lyrics::from_documents(
-            LyricsOrigin::Local,
-            vec![LyricsDocument {
-                role: LyricsRole::Original,
-                language: None,
-                offset_millis: 0,
-                lines,
-                agents: Vec::new(),
-            }],
-        )
-    })
+    lyrics_from_local_text(&content)
 }
 fn local_sidecar_candidates(
     audio_path: &Path,
@@ -1867,4 +2115,61 @@ fn read_bytes_bounded<R: Read>(mut reader: R, limit: usize, context: &str) -> io
 }
 fn bytes_to_mib(bytes: usize) -> usize {
     bytes / 1024 / 1024
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enhanced_lrc_preserves_unicode_word_ranges_and_round_trips() {
+        let content = "[00:01.000]<00:01.100>君と <00:01.600>blue";
+        let lyrics = lyrics_from_text_content(LyricsOrigin::Local, content);
+        let document = &lyrics.documents()[0];
+        let line = &document.lines[0];
+
+        assert_eq!(line.text, "君と blue");
+        assert!(document.has_word_timing());
+        assert_eq!(line.cue_lines[0].cues[0].start_millis, 1_100);
+        for cue in &line.cue_lines[0].cues {
+            assert_eq!(
+                line.text.get(cue.byte_start..cue.byte_end_exclusive),
+                Some(cue.text.as_str())
+            );
+        }
+        assert_eq!(lyrics_to_lrc_text(document, 0), content);
+    }
+
+    #[test]
+    fn text_offset_shifts_line_and_word_timestamps_together() {
+        let content = "[ar:Artist]\n[00:28.400]<00:28.400>君と <00:28.900>blue";
+
+        assert_eq!(
+            shift_lrc_text_timestamps(content, 100),
+            "[ar:Artist]\n[00:28.300]<00:28.300>君と <00:28.800>blue",
+        );
+        assert_eq!(
+            shift_lrc_text_timestamps(content, -100),
+            "[ar:Artist]\n[00:28.500]<00:28.500>君と <00:29.000>blue",
+        );
+    }
+
+    #[test]
+    fn netease_yrc_becomes_the_original_word_timed_document() {
+        let response = serde_json::from_str::<NeteaseLyricsResponse>(
+            r#"{
+                "lrc":{"lyric":"[00:01.00]line timed fallback"},
+                "yrc":{"lyric":"[1000,1000](1000,400,0)君と (1400,600,0)blue"}
+            }"#,
+        )
+        .expect("NetEase response");
+        let lyrics = lyrics_from_netease_response(response).expect("lyrics");
+        let document = &lyrics.documents()[0];
+
+        assert_eq!(document.lines[0].text, "君と blue");
+        assert_eq!(document.lines[0].start_millis, Some(1_000));
+        assert_eq!(document.lines[0].end_millis, Some(2_000));
+        assert_eq!(document.lines[0].cue_lines[0].cues.len(), 2);
+        assert!(document.has_word_timing());
+    }
 }

--- a/crates/metadata-lookup/src/http.rs
+++ b/crates/metadata-lookup/src/http.rs
@@ -1,4 +1,5 @@
 use std::io::Read;
+use std::net::{IpAddr, Ipv4Addr};
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
@@ -21,6 +22,21 @@ pub(crate) fn client() -> Result<&'static Client, String> {
     CLIENT
         .get_or_init(|| {
             Client::builder()
+                .timeout(Duration::from_secs(8))
+                .user_agent(USER_AGENT)
+                .build()
+                .map_err(|error| error.to_string())
+        })
+        .as_ref()
+        .map_err(Clone::clone)
+}
+
+pub(crate) fn ipv4_client() -> Result<&'static Client, String> {
+    static CLIENT: OnceLock<Result<Client, String>> = OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            Client::builder()
+                .local_address(IpAddr::V4(Ipv4Addr::UNSPECIFIED))
                 .timeout(Duration::from_secs(8))
                 .user_agent(USER_AGENT)
                 .build()

--- a/crates/metadata-lookup/src/musicbrainz.rs
+++ b/crates/metadata-lookup/src/musicbrainz.rs
@@ -8,7 +8,7 @@ use reqwest::blocking::Client;
 use serde_json::Value;
 use sources::{AlbumMetadataValues, ArtistMetadataValues, TrackMetadataValues};
 
-use crate::http::{client, fetch_json, fetch_optional_json};
+use crate::http::{fetch_json, fetch_optional_json, ipv4_client as client};
 
 const MUSICBRAINZ_RELEASE_SEARCH_URL: &str = "https://musicbrainz.org/ws/2/release/";
 const MUSICBRAINZ_RELEASE_GROUP_SEARCH_URL: &str = "https://musicbrainz.org/ws/2/release-group/";

--- a/crates/rufin/src/album_release.rs
+++ b/crates/rufin/src/album_release.rs
@@ -12,7 +12,7 @@ use ui::runtime::{CatalogChange, CatalogPublication, SourceEvent};
 use crate::settings::SettingsFile;
 use crate::source::WeakActiveSource;
 
-const LOOKUP_LIMIT: usize = 100;
+const LOOKUP_LIMIT: usize = 8;
 
 pub(crate) async fn run_selected_album_release_lookup(
     settings: SettingsFile,
@@ -26,92 +26,83 @@ pub(crate) async fn run_selected_album_release_lookup(
     let mut found = 0;
     let mut missing = 0;
     let mut errors = 0;
-    while lookup_allowed(&settings, &cancelled) {
-        let Some(current) = selected.upgrade().and_then(|session| session.resolve()) else {
-            break;
-        };
-        if current.source_key != source_key || current.source_session_epoch != source_session_epoch
-        {
+    let Some(current) = selected.upgrade().and_then(|session| session.resolve()) else {
+        return;
+    };
+    if current.source_key != source_key
+        || current.source_session_epoch != source_session_epoch
+        || !lookup_allowed(&settings, &cancelled)
+    {
+        return;
+    }
+    let candidates = match current
+        .database
+        .album_release_candidates(source_key, LOOKUP_LIMIT, &ReadCancellation::new())
+        .await
+    {
+        Ok(candidates) => candidates,
+        Err(error) => {
+            warn!(%error, %source_key, "could not read Album release candidates");
+            return;
+        }
+    };
+    for candidate in candidates {
+        if !lookup_allowed(&settings, &cancelled) {
             break;
         }
-        let candidates = match current
+        requested += 1;
+        let identity = candidate.lookup_identity.clone();
+        let lookup_identity = identity.clone();
+        let lookup = tokio::task::spawn_blocking(move || {
+            let (release_group, release) =
+                lookup_identity.strip_prefix("release-group:").map_or_else(
+                    || (None, lookup_identity.strip_prefix("release:")),
+                    |id| (Some(id), None),
+                );
+            metadata_lookup::lookup_album_release(release_group, release)
+        })
+        .await;
+        let result = match lookup {
+            Ok(Ok(Some(metadata))) => {
+                found += 1;
+                AlbumReleaseResult::Found {
+                    release_types: metadata.release_types,
+                }
+            }
+            Ok(Ok(None)) => {
+                missing += 1;
+                AlbumReleaseResult::Missing
+            }
+            Ok(Err(error)) => {
+                errors += 1;
+                warn!(%error, album_key = %candidate.album_key, "Album release lookup failed");
+                break;
+            }
+            Err(error) => {
+                errors += 1;
+                warn!(%error, album_key = %candidate.album_key, "Album release worker failed");
+                break;
+            }
+        };
+        match current
             .database
-            .album_release_candidates(source_key, LOOKUP_LIMIT, &ReadCancellation::new())
+            .accept_album_release_result(source_key, candidate.album_key, identity.as_str(), result)
             .await
         {
-            Ok(candidates) => candidates,
-            Err(error) => {
-                warn!(%error, %source_key, "could not read Album release candidates");
-                break;
-            }
-        };
-        let count = candidates.len();
-        requested += count;
-        let errors_before = errors;
-        for candidate in candidates {
-            if !lookup_allowed(&settings, &cancelled) {
-                break;
-            }
-            let identity = candidate.lookup_identity.clone();
-            let lookup_identity = identity.clone();
-            let lookup = tokio::task::spawn_blocking(move || {
-                let (release_group, release) =
-                    lookup_identity.strip_prefix("release-group:").map_or_else(
-                        || (None, lookup_identity.strip_prefix("release:")),
-                        |id| (Some(id), None),
-                    );
-                metadata_lookup::lookup_album_release(release_group, release)
-            })
-            .await;
-            let result = match lookup {
-                Ok(Ok(Some(metadata))) => {
-                    found += 1;
-                    AlbumReleaseResult::Found {
-                        release_types: metadata.release_types,
-                    }
-                }
-                Ok(Ok(None)) => {
-                    missing += 1;
-                    AlbumReleaseResult::Missing
-                }
-                Ok(Err(error)) => {
-                    errors += 1;
-                    warn!(%error, album_key = %candidate.album_key, "Album release lookup failed");
-                    continue;
-                }
-                Err(error) => {
-                    errors += 1;
-                    warn!(%error, album_key = %candidate.album_key, "Album release worker failed");
-                    continue;
-                }
-            };
-            match current
-                .database
-                .accept_album_release_result(
+            Ok(Some(_)) => {
+                let _ = events.try_send(SourceEvent::CatalogPublished(CatalogPublication {
                     source_key,
-                    candidate.album_key,
-                    identity.as_str(),
-                    result,
-                )
-                .await
-            {
-                Ok(Some(_)) => {
-                    let _ = events.try_send(SourceEvent::CatalogPublished(CatalogPublication {
-                        source_key,
-                        source_session_epoch,
-                        favorite: None,
-                        change: CatalogChange::Album(candidate.album_key),
-                    }));
-                }
-                Ok(None) => {}
-                Err(error) => {
-                    errors += 1;
-                    warn!(%error, "could not accept Album release result");
-                }
+                    source_session_epoch,
+                    favorite: None,
+                    change: CatalogChange::Album(candidate.album_key),
+                }));
             }
-        }
-        if count < LOOKUP_LIMIT || errors > errors_before {
-            break;
+            Ok(None) => {}
+            Err(error) => {
+                errors += 1;
+                warn!(%error, "could not accept Album release result");
+                break;
+            }
         }
     }
     info!(%source_key, requested, found, missing, errors, "completed Album release lookup");

--- a/crates/rufin/src/source/mod.rs
+++ b/crates/rufin/src/source/mod.rs
@@ -61,6 +61,7 @@ pub(crate) struct SelectedSourceState {
     pub(crate) album_count: usize,
     pub(crate) track_count: usize,
     pub(crate) mapped_count: usize,
+    pub(crate) sample_source_path: Option<String>,
 }
 
 impl SelectedSourceState {
@@ -611,6 +612,14 @@ impl SourceOwner {
             .mapping_access_count(publication.source, &cancellation)
             .await
             .map_err(string_error)?;
+        let sample_source_path = self
+            .shared
+            .database
+            .mapping_track_page(publication.source, None, None, 1, &cancellation)
+            .await
+            .map_err(string_error)?
+            .pop()
+            .map(|track| track.source_path);
         let selected = Arc::new(SelectedSourceState {
             configuration: configured.configuration.clone(),
             source,
@@ -627,6 +636,7 @@ impl SourceOwner {
             album_count,
             track_count,
             mapped_count,
+            sample_source_path,
         });
         let session = ActiveSource::new(&self.shared, &selected);
         let playback = self.shared.playback()?;
@@ -2149,26 +2159,14 @@ impl SelectedSourcePort for ActiveSource {
 
     fn identify_track_metadata(
         &self,
-        track: TrackKey,
+        _track: TrackKey,
         values: TrackMetadataValues,
     ) -> Receiver<Result<Option<(TrackMetadataValues, Option<String>)>, String>> {
         let external = self
             .shared
             .upgrade()
             .is_some_and(|shared| shared.settings.load().ui.allows_external_metadata_lookup());
-        self.spawn_reply(move |selected| async move {
-            if let Some(source) = selected.source.clone()
-                && let Some((values, token)) = source
-                    .identify_track_metadata(
-                        &selected.database,
-                        selected.source_key,
-                        track,
-                        &values,
-                    )
-                    .await?
-            {
-                return Ok(Some((values, Some(token))));
-            }
+        self.spawn_reply(move |_| async move {
             if !external {
                 return Ok(None);
             }
@@ -2189,6 +2187,27 @@ impl SelectedSourcePort for ActiveSource {
             .upgrade()
             .is_some_and(|shared| shared.settings.load().ui.allows_external_metadata_lookup());
         self.spawn_reply(move |selected| async move {
+            let exact_external = external
+                && (values
+                    .musicbrainz_album_id
+                    .as_deref()
+                    .is_some_and(|id| !id.trim().is_empty())
+                    || values
+                        .musicbrainz_release_group_id
+                        .as_deref()
+                        .is_some_and(|id| !id.trim().is_empty()));
+            if exact_external {
+                let external_values = values.clone();
+                match tokio::task::spawn_blocking(move || {
+                    metadata_lookup::identify_album_metadata(&external_values)
+                })
+                .await
+                .map_err(string_error)??
+                {
+                    Some(values) => return Ok(Some((values, None))),
+                    None => {}
+                }
+            }
             if let Some(source) = selected.source.clone()
                 && let Some((values, token)) = source
                     .identify_album_metadata(
@@ -2221,6 +2240,23 @@ impl SelectedSourcePort for ActiveSource {
             .upgrade()
             .is_some_and(|shared| shared.settings.load().ui.allows_external_metadata_lookup());
         self.spawn_reply(move |selected| async move {
+            let exact_external = external
+                && values
+                    .musicbrainz_artist_id
+                    .as_deref()
+                    .is_some_and(|id| !id.trim().is_empty());
+            if exact_external {
+                let external_values = values.clone();
+                match tokio::task::spawn_blocking(move || {
+                    metadata_lookup::identify_artist_metadata(&external_values)
+                })
+                .await
+                .map_err(string_error)??
+                {
+                    Some(values) => return Ok(Some((values, None))),
+                    None => {}
+                }
+            }
             if let Some(source) = selected.source.clone()
                 && let Some((values, token)) = source
                     .identify_artist_metadata(
@@ -2586,7 +2622,7 @@ fn configured_sources(
                             unmatched_count: selected
                                 .track_count
                                 .saturating_sub(selected.mapped_count),
-                            sample_source_path: None,
+                            sample_source_path: selected.sample_source_path.clone(),
                             sample_local_path: None,
                         }
                     })

--- a/crates/sources/src/jellyfin/client.rs
+++ b/crates/sources/src/jellyfin/client.rs
@@ -504,26 +504,8 @@ impl JellyfinSource {
 }
 
 impl JellyfinSource {
-    pub(crate) async fn lyrics(
-        &self,
-        track_id: &str,
-        search: LyricsSearch,
-    ) -> SourceResult<Option<NativeLyrics>> {
-        match search {
-            LyricsSearch::ServerOnly => self.server_lyrics(track_id).await,
-            LyricsSearch::ServerThenRemote => {
-                if let Some(lyrics) = self.server_lyrics(track_id).await? {
-                    return Ok(Some(lyrics));
-                }
-                self.remote_lyrics(track_id).await
-            }
-            LyricsSearch::RemoteThenServer => {
-                if let Some(lyrics) = self.remote_lyrics(track_id).await? {
-                    return Ok(Some(lyrics));
-                }
-                self.server_lyrics(track_id).await
-            }
-        }
+    pub(crate) async fn lyrics(&self, track_id: &str) -> SourceResult<Option<NativeLyrics>> {
+        self.server_lyrics(track_id).await
     }
 }
 
@@ -827,35 +809,24 @@ impl JellyfinSource {
         send_unit(request.header(header::AUTHORIZATION, self.authorization.clone())).await
     }
 
+    pub(crate) async fn write_lyrics(&self, track_id: &str, lyrics: &str) -> SourceResult<()> {
+        let raw_track_id = raw_item_id(track_id);
+        let mut url = endpoint(&self.base_url, &format!("Audio/{raw_track_id}/Lyrics"))?;
+        url.query_pairs_mut().append_pair("fileName", "lyrics.lrc");
+        self.send_json::<LyricDto>(
+            self.client
+                .post(url)
+                .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
+                .body(lyrics.to_string()),
+        )
+        .await
+        .map(|_| ())
+    }
+
     async fn server_lyrics(&self, track_id: &str) -> SourceResult<Option<NativeLyrics>> {
         let raw_track_id = raw_item_id(track_id);
         let local_url = endpoint(&self.base_url, &format!("Audio/{raw_track_id}/Lyrics"))?;
         match self.send_json::<LyricDto>(self.client.get(local_url)).await {
-            Ok(dto) => Ok(Some(lyrics_from_dto(dto))),
-            Err(SourceError::NotFound) => Ok(None),
-            Err(error) => Err(error),
-        }
-    }
-
-    async fn remote_lyrics(&self, track_id: &str) -> SourceResult<Option<NativeLyrics>> {
-        let raw_track_id = raw_item_id(track_id);
-        let remote_url = endpoint(
-            &self.base_url,
-            &format!("Audio/{raw_track_id}/RemoteSearch/Lyrics"),
-        )?;
-        let results = match self
-            .send_json::<Vec<RemoteLyricInfoDto>>(self.client.get(remote_url))
-            .await
-        {
-            Ok(results) => results,
-            Err(SourceError::NotFound) => return Ok(None),
-            Err(error) => return Err(error),
-        };
-        let Some(first) = results.into_iter().find(|result| !result.id.is_empty()) else {
-            return Ok(None);
-        };
-        let lyric_url = endpoint(&self.base_url, &format!("Providers/Lyrics/{}", first.id))?;
-        match self.send_json::<LyricDto>(self.client.get(lyric_url)).await {
             Ok(dto) => Ok(Some(lyrics_from_dto(dto))),
             Err(SourceError::NotFound) => Ok(None),
             Err(error) => Err(error),
@@ -953,12 +924,6 @@ pub(super) struct LyricLineDto {
     pub(super) start: Option<i64>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-pub(super) struct RemoteLyricInfoDto {
-    pub(super) id: String,
-}
-
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub(super) struct PlaybackReportDto {
@@ -1003,7 +968,7 @@ mod tests {
         JellyfinItem, album_from_item, stage_album, stage_track, track_from_item,
     };
     use crate::jellyfin::{JellyfinSource, JellyfinSourceConfig};
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{body_string, method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
@@ -1060,6 +1025,39 @@ mod tests {
         assert!(stream.uri().contains("secret-token"));
         assert!(!stream.redacted_uri().contains("secret-token"));
         assert!(stream.redacted_uri().contains("api_key=%3Credacted%3E"));
+    }
+
+    #[tokio::test]
+    async fn jellyfin_lyrics_write_uses_the_managed_upload_endpoint() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/Audio/track-one/Lyrics"))
+            .and(query_param("fileName", "lyrics.lrc"))
+            .and(body_string("[00:01.000]Line"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "Lyrics": []
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let source = JellyfinSource::open(
+            JellyfinSourceConfig {
+                base_url: server.uri(),
+                server_id: Some("server-one".to_string()),
+                user_id: "user-one".to_string(),
+                username: "listener".to_string(),
+                trust_invalid_cert: false,
+                use_instant_mix: false,
+            },
+            "secret-token".to_string(),
+            "device-one".to_string(),
+        )
+        .expect("Jellyfin source");
+
+        source
+            .write_lyrics("jellyfin:track:track-one", "[00:01.000]Line")
+            .await
+            .expect("upload lyrics");
     }
 
     #[tokio::test]

--- a/crates/sources/src/jellyfin/metadata.rs
+++ b/crates/sources/src/jellyfin/metadata.rs
@@ -49,7 +49,7 @@ impl JellyfinSource {
         Ok(TrackMetadata {
             track_key: track.track_key,
             writable: track_writable(&editor),
-            source_search: true,
+            source_search: false,
             revision: Some(revision(&item)?),
             source_values,
             values,
@@ -182,22 +182,27 @@ impl JellyfinSource {
         values: &AlbumMetadataValues,
     ) -> Result<Option<(AlbumMetadataValues, String)>, String> {
         let raw = raw_id(object_id, "album").map_err(|error| error.to_string())?;
-        let results = self
-            .remote_search(raw, "MusicAlbum", &values.title, values.year)
-            .await?;
+        let mut search_info = json!({
+            "Name": values.title,
+            "Year": values.year,
+            "ProviderIds": identification_provider_ids([
+                ("MusicBrainzAlbum", values.musicbrainz_album_id.as_deref()),
+                (
+                    "MusicBrainzReleaseGroup",
+                    values.musicbrainz_release_group_id.as_deref(),
+                ),
+            ]),
+        });
+        let album_artists =
+            split_values(values.album_artist.as_deref().or(values.artist.as_deref()));
+        if !album_artists.is_empty() {
+            search_info
+                .as_object_mut()
+                .expect("Jellyfin search info object")
+                .insert("AlbumArtists".to_string(), json!(album_artists));
+        }
+        let results = self.remote_search(raw, "MusicAlbum", search_info).await?;
         Ok(select_album_identification(values, &results))
-    }
-
-    pub(crate) async fn identify_track_metadata(
-        &self,
-        object_id: &str,
-        values: &TrackMetadataValues,
-    ) -> Result<Option<(TrackMetadataValues, String)>, String> {
-        let raw = raw_id(object_id, "track").map_err(|error| error.to_string())?;
-        let results = self
-            .remote_search(raw, "Audio", &values.title, values.year)
-            .await?;
-        Ok(select_track_identification(values, &results))
     }
 
     pub(crate) async fn identify_artist_metadata(
@@ -206,9 +211,13 @@ impl JellyfinSource {
         values: &ArtistMetadataValues,
     ) -> Result<Option<(ArtistMetadataValues, String)>, String> {
         let raw = raw_id(object_id, "artist").map_err(|error| error.to_string())?;
-        let results = self
-            .remote_search(raw, "MusicArtist", &values.name, None)
-            .await?;
+        let search_info = json!({
+            "Name": values.name,
+            "ProviderIds": identification_provider_ids([
+                ("MusicBrainzArtist", values.musicbrainz_artist_id.as_deref()),
+            ]),
+        });
+        let results = self.remote_search(raw, "MusicArtist", search_info).await?;
         Ok(select_artist_identification(values, &results))
     }
 
@@ -216,21 +225,45 @@ impl JellyfinSource {
         &self,
         raw: &str,
         item_type: &str,
-        name: &str,
-        year: Option<u16>,
+        search_info: Value,
     ) -> Result<Vec<Value>, String> {
-        if name.trim().is_empty() {
+        if search_info
+            .get("Name")
+            .and_then(Value::as_str)
+            .is_none_or(|name| name.trim().is_empty())
+            && search_info
+                .get("ProviderIds")
+                .and_then(Value::as_object)
+                .is_none_or(Map::is_empty)
+        {
             return Ok(Vec::new());
         }
         let url = endpoint(&self.base_url, &format!("Items/RemoteSearch/{item_type}"))
             .map_err(|error| error.to_string())?;
         self.send_json(self.client.post(url).json(&json!({
             "ItemId": raw,
-            "SearchInfo": { "Name": name, "Year": year }
+            "SearchInfo": search_info,
         })))
         .await
         .map_err(|error| error.to_string())
     }
+}
+
+fn identification_provider_ids<'a>(
+    values: impl IntoIterator<Item = (&'a str, Option<&'a str>)>,
+) -> Map<String, Value> {
+    values
+        .into_iter()
+        .filter_map(|(key, value)| Some((key.to_string(), Value::String(clean(value?)?))))
+        .collect()
+}
+
+fn split_values(value: Option<&str>) -> Vec<String> {
+    value
+        .into_iter()
+        .flat_map(|value| value.split(';'))
+        .filter_map(clean)
+        .collect()
 }
 
 pub(crate) fn apply_track_edit(item: &mut Map<String, Value>, edit: &crate::TrackMetadataEdit) {
@@ -520,47 +553,6 @@ fn select_album_identification(
     Some((values, serde_json::to_string(selected).ok()?))
 }
 
-fn select_track_identification(
-    previous: &TrackMetadataValues,
-    results: &[Value],
-) -> Option<(TrackMetadataValues, String)> {
-    let exact = results
-        .iter()
-        .filter(|value| {
-            previous
-                .musicbrainz_recording_id
-                .as_deref()
-                .is_some_and(|id| provider(value, "MusicBrainzRecording").as_deref() == Some(id))
-                || previous
-                    .musicbrainz_release_track_id
-                    .as_deref()
-                    .is_some_and(|id| provider(value, "MusicBrainzTrack").as_deref() == Some(id))
-        })
-        .collect::<Vec<_>>();
-    let selected = match exact.as_slice() {
-        [one] => *one,
-        [] => select_result(&previous.title, previous.year, results)?,
-        _ => return None,
-    };
-    let mut values = previous.clone();
-    values.title = string(selected, "Name").unwrap_or_else(|| values.title.clone());
-    values.year = number(selected, "ProductionYear").or(values.year);
-    values.artist = named(selected, "ArtistItems")
-        .or_else(|| string_array(selected, "Artists"))
-        .or(values.artist);
-    values.album = string(selected, "Album").or(values.album);
-    values.album_artist = named(selected, "AlbumArtists").or(values.album_artist);
-    values.musicbrainz_recording_id =
-        provider(selected, "MusicBrainzRecording").or(values.musicbrainz_recording_id);
-    values.musicbrainz_release_track_id =
-        provider(selected, "MusicBrainzTrack").or(values.musicbrainz_release_track_id);
-    values.musicbrainz_album_id =
-        provider(selected, "MusicBrainzAlbum").or(values.musicbrainz_album_id);
-    values.musicbrainz_release_group_id =
-        provider(selected, "MusicBrainzReleaseGroup").or(values.musicbrainz_release_group_id);
-    Some((values, serde_json::to_string(selected).ok()?))
-}
-
 fn select_artist_identification(
     previous: &ArtistMetadataValues,
     results: &[Value],
@@ -750,7 +742,7 @@ fn preserve_complete_artist_items(item: &mut Map<String, Value>) {
 #[cfg(test)]
 mod tests {
 
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{body_json, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::*;
@@ -773,19 +765,7 @@ mod tests {
             })))
             .mount(&server)
             .await;
-        let source = JellyfinSource::open(
-            super::super::JellyfinSourceConfig {
-                base_url: server.uri(),
-                server_id: None,
-                user_id: "user".to_string(),
-                username: "listener".to_string(),
-                trust_invalid_cert: false,
-                use_instant_mix: false,
-            },
-            "token".to_string(),
-            "device".to_string(),
-        )
-        .expect("open Jellyfin");
+        let source = test_source(&server);
         let mut row = track_row();
         row.musicbrainz_release_track_id = Some("rufin-release-track".to_string());
         let metadata = source
@@ -794,6 +774,7 @@ mod tests {
             .expect("read Track metadata");
         assert!(metadata.writable.title);
         assert!(metadata.writable.musicbrainz_recording_id);
+        assert!(!metadata.source_search);
         assert_eq!(metadata.revision.as_deref(), Some("etag:revision"));
         assert_eq!(metadata.values.title, "Provider title");
         assert_eq!(
@@ -806,6 +787,46 @@ mod tests {
             Some("rufin-release-track")
         );
         assert!(metadata.rufin_filled.musicbrainz_release_track_id);
+    }
+
+    #[tokio::test]
+    async fn jellyfin_album_identification_keeps_exact_ids_and_artist_credits() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/Items/RemoteSearch/MusicAlbum"))
+            .and(body_json(json!({
+                "ItemId": "album",
+                "SearchInfo": {
+                    "Name": "Album",
+                    "Year": 2024,
+                    "ProviderIds": {
+                        "MusicBrainzAlbum": "release",
+                        "MusicBrainzReleaseGroup": "release-group",
+                    },
+                    "AlbumArtists": ["Artist", "Guest"],
+                },
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .mount(&server)
+            .await;
+        let source = test_source(&server);
+
+        let result = source
+            .identify_album_metadata(
+                "jellyfin:album:album",
+                &AlbumMetadataValues {
+                    title: "Album".to_string(),
+                    album_artist: Some("Artist; Guest".to_string()),
+                    year: Some(2024),
+                    musicbrainz_album_id: Some("release".to_string()),
+                    musicbrainz_release_group_id: Some("release-group".to_string()),
+                    ..AlbumMetadataValues::default()
+                },
+            )
+            .await
+            .expect("identify Jellyfin Album");
+
+        assert!(result.is_none());
     }
 
     #[test]
@@ -832,30 +853,6 @@ mod tests {
             },
         );
         assert_eq!(item["ArtistItems"], original);
-    }
-
-    #[test]
-    fn track_identification_prefers_the_exact_recording_identity() {
-        let previous = TrackMetadataValues {
-            title: "Current title".to_string(),
-            musicbrainz_recording_id: Some("recording".to_string()),
-            ..TrackMetadataValues::default()
-        };
-        let results = vec![
-            json!({"Name":"Wrong", "ProviderIds":{"MusicBrainzRecording":"other"}}),
-            json!({
-                "Name":"Identified title",
-                "Artists":["Identified artist"],
-                "Album":"Identified album",
-                "ProviderIds":{"MusicBrainzRecording":"recording"}
-            }),
-        ];
-
-        let (identified, _) =
-            select_track_identification(&previous, &results).expect("exact identification");
-        assert_eq!(identified.title, "Identified title");
-        assert_eq!(identified.artist.as_deref(), Some("Identified artist"));
-        assert_eq!(identified.album.as_deref(), Some("Identified album"));
     }
 
     fn track_row() -> library::TrackRow {
@@ -895,5 +892,21 @@ mod tests {
             album_artists: Vec::new(),
             genres: Vec::new(),
         }
+    }
+
+    fn test_source(server: &MockServer) -> JellyfinSource {
+        JellyfinSource::open(
+            super::super::JellyfinSourceConfig {
+                base_url: server.uri(),
+                server_id: None,
+                user_id: "user".to_string(),
+                username: "listener".to_string(),
+                trust_invalid_cert: false,
+                use_instant_mix: false,
+            },
+            "token".to_string(),
+            "device".to_string(),
+        )
+        .expect("open Jellyfin")
     }
 }

--- a/crates/sources/src/jellyfin/mod.rs
+++ b/crates/sources/src/jellyfin/mod.rs
@@ -2,8 +2,8 @@ use crate::config::{decode_provider_payload, require_payload_version};
 use crate::policy::{raw_item_id, stable_hash};
 use crate::{
     ConnectedSource, CredentialHostInput, ImageBytes, JellyfinSettingsInput, JellyfinSetupInput,
-    LyricsSearch, NativeLyricLine, NativeLyrics, NativeLyricsDocument, NativeLyricsRole,
-    SourceConfiguration, SourceEditResult, SourceError, SourceId, SourceResult,
+    NativeLyricLine, NativeLyrics, NativeLyricsDocument, NativeLyricsRole, SourceConfiguration,
+    SourceEditResult, SourceError, SourceId, SourceResult,
 };
 pub use discovery::{DiscoveredJellyfinServer, discover_jellyfin_servers};
 use item::{

--- a/crates/sources/src/lib.rs
+++ b/crates/sources/src/lib.rs
@@ -35,7 +35,7 @@ pub use config::{
 pub use operations::{
     AlbumMetadata, AlbumMetadataEdit, AlbumMetadataMixed, AlbumMetadataValues,
     AlbumMetadataWritable, ArtistMetadata, ArtistMetadataEdit, ArtistMetadataMixed,
-    ArtistMetadataValues, ArtistMetadataWritable, ImageBytes, LyricsSearch, NativeLyricAgent,
+    ArtistMetadataValues, ArtistMetadataWritable, ImageBytes, NativeLyricAgent,
     NativeLyricAgentRole, NativeLyricCue, NativeLyricCueLine, NativeLyricLine, NativeLyrics,
     NativeLyricsDocument, NativeLyricsRole, SourceMetadataError, TrackMetadata, TrackMetadataEdit,
     TrackMetadataValues, TrackMetadataWritable,
@@ -43,7 +43,9 @@ pub use operations::{
 pub use source::*;
 
 pub use jellyfin::{DiscoveredJellyfinServer, discover_jellyfin_servers};
-pub use local::{LOCAL_LIBRARY_SOURCE_ID, LOCAL_SOURCE_ID, verify_local_media_file};
+pub use local::{
+    LOCAL_LIBRARY_SOURCE_ID, LOCAL_SOURCE_ID, read_embedded_lyrics, verify_local_media_file,
+};
 pub use subsonic::{SubsonicAuthentication, SubsonicFlavor};
 
 use thiserror::Error;

--- a/crates/sources/src/local/lofty_metadata.rs
+++ b/crates/sources/src/local/lofty_metadata.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use lofty::config::{GlobalOptions, ParseOptions, apply_global_options};
 use lofty::file::{FileType, TaggedFile};
 use lofty::probe::Probe;
-use lofty::tag::ItemKey;
+use lofty::tag::{ItemKey, TagType};
 
 const LOFTY_ALLOCATION_MAX_BYTES: usize = 32 * 1024 * 1024;
 
@@ -38,6 +38,23 @@ impl MetadataWriter {
 
     pub(super) fn metadata_key_is_writable(self, key: ItemKey) -> bool {
         metadata_key_is_writable(self.file_type.primary_tag_type(), key)
+    }
+
+    pub(super) fn lyrics_target(self) -> Option<(TagType, ItemKey)> {
+        let primary = self.file_type.primary_tag_type();
+        for key in [ItemKey::UnsyncLyrics, ItemKey::Lyrics] {
+            if metadata_key_is_writable(primary, key) {
+                return Some((primary, key));
+            }
+        }
+        if self.file_type.tag_support(TagType::Id3v2).is_writable() {
+            for key in [ItemKey::UnsyncLyrics, ItemKey::Lyrics] {
+                if metadata_key_is_writable(TagType::Id3v2, key) {
+                    return Some((TagType::Id3v2, key));
+                }
+            }
+        }
+        None
     }
 }
 

--- a/crates/sources/src/local/metadata.rs
+++ b/crates/sources/src/local/metadata.rs
@@ -10,7 +10,7 @@ use lofty::prelude::{Accessor, TagExt};
 use lofty::tag::items::popularimeter::{Popularimeter, StarRating};
 use lofty::tag::{ItemKey, Tag};
 
-use super::lofty_metadata::{MetadataWriter, bpm_key, read_lofty_for_edit};
+use super::lofty_metadata::{MetadataWriter, bpm_key, read_lofty, read_lofty_for_edit};
 use crate::{AlbumMetadataEdit, ArtistMetadataEdit, SourceMetadataError, TrackMetadataEdit};
 
 pub(crate) fn revision(path: &Path) -> Result<String, SourceMetadataError> {
@@ -44,7 +44,7 @@ pub(crate) fn write_track(
     }
     let values = &edit.values;
     let changed = &edit.changed;
-    let prepared = prepare_file(path, source_format, |tag, writer| {
+    let prepared = prepare_file(path, source_format, None, |tag, writer| {
         if changed.title {
             tag.set_title(values.title.trim().to_string());
         }
@@ -132,7 +132,7 @@ pub(crate) fn write_rating(
     source_format: Option<&str>,
     rating: Option<u8>,
 ) -> Result<(), SourceMetadataError> {
-    let prepared = prepare_file(path, source_format, |tag, _| {
+    let prepared = prepare_file(path, source_format, None, |tag, _| {
         tag.remove_key(ItemKey::Popularimeter);
         if let Some(rating) = rating.filter(|rating| *rating > 0) {
             let stars = rating.div_ceil(2).clamp(1, 5);
@@ -152,6 +152,42 @@ pub(crate) fn write_rating(
     commit_batch(vec![prepared])
 }
 
+pub(super) fn read_embedded_lyrics(path: &Path) -> Result<Option<String>, SourceMetadataError> {
+    let tagged = read_lofty(path, false)
+        .map_err(write_error)?
+        .ok_or(SourceMetadataError::Unavailable)?;
+    Ok(tagged.tags().iter().find_map(|tag| {
+        [ItemKey::UnsyncLyrics, ItemKey::Lyrics]
+            .into_iter()
+            .find_map(|key| tag.get_string(key))
+            .map(ToString::to_string)
+            .filter(|lyrics| !lyrics.trim().is_empty())
+    }))
+}
+
+pub(super) fn write_embedded_lyrics(path: &Path, lyrics: &str) -> Result<(), SourceMetadataError> {
+    let writer = MetadataWriter::for_path(path).ok_or(SourceMetadataError::Unavailable)?;
+    if matches!(
+        writer.file_type(),
+        lofty::file::FileType::Wav | lofty::file::FileType::Aiff
+    ) {
+        return Err(SourceMetadataError::Unavailable);
+    }
+    let (tag_type, key) = writer
+        .lyrics_target()
+        .ok_or(SourceMetadataError::Unavailable)?;
+    let prepared = prepare_file(path, None, Some(tag_type), |tag, _| {
+        set_embedded_lyrics(tag, key, lyrics);
+    })?;
+    commit_batch(vec![prepared])
+}
+
+fn set_embedded_lyrics(tag: &mut Tag, key: ItemKey, lyrics: &str) {
+    tag.remove_key(ItemKey::UnsyncLyrics);
+    tag.remove_key(ItemKey::Lyrics);
+    tag.insert_text(key, lyrics.to_string());
+}
+
 pub(crate) fn write_r128(
     path: &Path,
     source_format: Option<&str>,
@@ -167,7 +203,7 @@ pub(crate) fn write_r128(
     {
         return Err(SourceMetadataError::Unavailable);
     }
-    let prepared = prepare_file(path, source_format, |tag, _| {
+    let prepared = prepare_file(path, source_format, None, |tag, _| {
         if let Some(lufs) = track_lufs {
             set_text(tag, ItemKey::R128TrackGain, Some(&r128_gain_text(lufs)));
         }
@@ -199,7 +235,7 @@ pub(crate) fn write_album_batch(
     let changed = &edit.changed;
     let mut prepared = Vec::with_capacity(targets.len());
     for (path, format) in targets {
-        prepared.push(prepare_file(path, format.as_deref(), |tag, _| {
+        prepared.push(prepare_file(path, format.as_deref(), None, |tag, _| {
             if changed.title {
                 set_text(tag, ItemKey::AlbumTitle, Some(&values.title));
             }
@@ -261,7 +297,7 @@ pub(crate) fn write_artist_batch(
     let changed = &edit.changed;
     let mut prepared = Vec::with_capacity(targets.len());
     for (path, format) in targets {
-        prepared.push(prepare_file(path, format.as_deref(), |tag, _| {
+        prepared.push(prepare_file(path, format.as_deref(), None, |tag, _| {
             if changed.name {
                 let artists = tag
                     .artist()
@@ -302,6 +338,7 @@ struct PreparedFile {
 fn prepare_file(
     path: &Path,
     source_format: Option<&str>,
+    tag_type: Option<lofty::tag::TagType>,
     mutate: impl FnOnce(&mut Tag, MetadataWriter),
 ) -> Result<PreparedFile, SourceMetadataError> {
     let writer = source_format
@@ -319,7 +356,16 @@ fn prepare_file(
     let tagged = read_lofty_for_edit(temp.path(), writer.file_type())
         .map_err(write_error)?
         .ok_or(SourceMetadataError::Unavailable)?;
-    let mut tag = writable_tag(&tagged);
+    let mut tag = tag_type
+        .map(|tag_type| {
+            tagged
+                .tags()
+                .iter()
+                .find(|tag| tag.tag_type() == tag_type)
+                .cloned()
+                .unwrap_or_else(|| Tag::new(tag_type))
+        })
+        .unwrap_or_else(|| writable_tag(&tagged));
     mutate(&mut tag, writer);
     save_tag(&tag, temp.path())?;
     temp.as_file().sync_all().map_err(write_error)?;
@@ -503,6 +549,42 @@ mod tests {
     }
 
     #[test]
+    fn embedded_lyrics_replace_id3_values_and_refuse_unsafe_wav_writes() {
+        let directory = tempfile::tempdir().expect("metadata directory");
+        let path = directory.path().join("track.wav");
+        fs::write(&path, silent_wav()).expect("write WAV");
+        let before = revision(&path).expect("file revision");
+        write_track(
+            &path,
+            Some("wav"),
+            &before,
+            &track_edit(TrackMetadataValues {
+                title: "Track title".to_string(),
+                ..TrackMetadataValues::default()
+            }),
+        )
+        .expect("seed metadata");
+
+        assert_eq!(
+            write_embedded_lyrics(&path, "[00:01.000]A line"),
+            Err(SourceMetadataError::Unavailable)
+        );
+        assert!(!super::super::embedded_lyrics_writable(&path));
+        assert_eq!(
+            super::super::read_track_metadata(library::TrackKey::from_raw(1), &path, Some("wav"))
+                .expect("read metadata")
+                .values
+                .title,
+            "Track title"
+        );
+
+        let mut id3 = Tag::new(lofty::tag::TagType::Id3v2);
+        set_embedded_lyrics(&mut id3, ItemKey::UnsyncLyrics, "first");
+        set_embedded_lyrics(&mut id3, ItemKey::UnsyncLyrics, "updated");
+        assert_eq!(id3.get_string(ItemKey::UnsyncLyrics), Some("updated"));
+    }
+
+    #[test]
     fn local_album_metadata_updates_each_backing_track_as_one_batch() {
         let directory = tempfile::tempdir().expect("metadata directory");
         let paths = [
@@ -603,7 +685,7 @@ mod tests {
         let second_original = directory.path().join("second.original");
         let prepared = [&first, &second]
             .into_iter()
-            .map(|path| prepare_file(path, Some("wav"), |_, _| {}))
+            .map(|path| prepare_file(path, Some("wav"), None, |_, _| {}))
             .collect::<Result<Vec<_>, _>>()
             .expect("prepared metadata files");
         fs::rename(&second, &second_original).expect("make second replacement fail");

--- a/crates/sources/src/local/mod.rs
+++ b/crates/sources/src/local/mod.rs
@@ -31,6 +31,26 @@ pub const LOCAL_SOURCE_ID: &str = "local";
 pub const LOCAL_LIBRARY_SOURCE_ID: &str = "local:server:library";
 const SOURCE_CONFIG_VERSION: u32 = 1;
 
+pub fn read_embedded_lyrics(path: &Path) -> Result<Option<String>, crate::SourceMetadataError> {
+    metadata::read_embedded_lyrics(path)
+}
+
+pub(super) fn write_embedded_lyrics(
+    path: &Path,
+    lyrics: &str,
+) -> Result<(), crate::SourceMetadataError> {
+    metadata::write_embedded_lyrics(path, lyrics)
+}
+
+pub(super) fn embedded_lyrics_writable(path: &Path) -> bool {
+    lofty_metadata::MetadataWriter::for_path(path).is_some_and(|writer| {
+        !matches!(
+            writer.file_type(),
+            lofty::file::FileType::Wav | lofty::file::FileType::Aiff
+        ) && writer.lyrics_target().is_some()
+    })
+}
+
 #[derive(Deserialize)]
 struct LocalSourcePayload {
     version: u32,

--- a/crates/sources/src/operations.rs
+++ b/crates/sources/src/operations.rs
@@ -168,7 +168,7 @@ pub struct ArtistMetadataMixed {
     pub musicbrainz_artist_id: bool,
 }
 
-#[derive(Debug, Error, Eq, PartialEq)]
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
 pub enum SourceMetadataError {
     #[error("metadata editing is unavailable")]
     Unavailable,
@@ -180,13 +180,6 @@ pub enum SourceMetadataError {
     SavedRefreshFailed(String),
     #[error("metadata failed: {0}")]
     Write(String),
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum LyricsSearch {
-    ServerOnly,
-    ServerThenRemote,
-    RemoteThenServer,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/sources/src/source.rs
+++ b/crates/sources/src/source.rs
@@ -796,6 +796,101 @@ impl Source {
         }
     }
 
+    pub async fn lyrics_writable(
+        &self,
+        database: &Database,
+        source: library::SourceKey,
+        track_key: library::TrackKey,
+    ) -> bool {
+        let Ok(Some(track)) = database
+            .track_rows(source, &[track_key], &library::ReadCancellation::new())
+            .await
+            .map(|mut rows| rows.pop())
+        else {
+            return false;
+        };
+        if track.cue_path.is_some() {
+            return false;
+        }
+        match &self.implementation {
+            Implementation::Jellyfin(_) => true,
+            Implementation::Local(_) | Implementation::OpenSubsonic(_) => {
+                let Ok((path, _)) = self.metadata_file_target(database, source, &track).await
+                else {
+                    return false;
+                };
+                (!matches!(self.implementation, Implementation::OpenSubsonic(_))
+                    || self.mapped_metadata_ready().await)
+                    && crate::local::embedded_lyrics_writable(&path)
+            }
+        }
+    }
+
+    pub async fn write_lyrics(
+        &self,
+        database: &Database,
+        source: library::SourceKey,
+        track_key: library::TrackKey,
+        lyrics: &str,
+    ) -> Result<(), crate::SourceMetadataError> {
+        let track = database
+            .track_rows(source, &[track_key], &library::ReadCancellation::new())
+            .await
+            .map_err(metadata_database_error)?
+            .pop()
+            .ok_or(crate::SourceMetadataError::Unavailable)?;
+        if track.cue_path.is_some() {
+            return Err(crate::SourceMetadataError::Unavailable);
+        }
+        match &self.implementation {
+            Implementation::Jellyfin(jellyfin) => jellyfin
+                .write_lyrics(&track.object_id, lyrics)
+                .await
+                .map_err(|error| crate::SourceMetadataError::Write(error.to_string())),
+            Implementation::Local(local) => {
+                let path = self
+                    .write_file_lyrics(database, source, &track, lyrics)
+                    .await?;
+                local
+                    .publish_paths(database, source, self.source_id.as_str(), &[path], None)
+                    .await
+                    .map(|_| ())
+                    .map_err(|error| {
+                        crate::SourceMetadataError::SavedRefreshFailed(error.to_string())
+                    })
+            }
+            Implementation::OpenSubsonic(_) => {
+                if !self.mapped_metadata_ready().await {
+                    return Err(crate::SourceMetadataError::Unavailable);
+                }
+                self.write_file_lyrics(database, source, &track, lyrics)
+                    .await
+                    .map(|_| ())
+            }
+        }
+    }
+
+    pub async fn refresh_written_lyrics(&self) -> Result<(), crate::SourceMetadataError> {
+        self.refresh_remote_metadata_index()
+            .await
+            .map_err(|error| crate::SourceMetadataError::SavedRefreshFailed(error.to_string()))
+    }
+
+    async fn write_file_lyrics(
+        &self,
+        database: &Database,
+        source: library::SourceKey,
+        track: &library::TrackRow,
+        lyrics: &str,
+    ) -> Result<PathBuf, crate::SourceMetadataError> {
+        let (path, _) = self.metadata_file_target(database, source, track).await?;
+        if !crate::local::embedded_lyrics_writable(&path) {
+            return Err(crate::SourceMetadataError::Unavailable);
+        }
+        crate::local::write_embedded_lyrics(&path, lyrics)?;
+        Ok(path)
+    }
+
     pub async fn read_track_metadata(
         &self,
         database: &Database,
@@ -812,11 +907,12 @@ impl Source {
         if let Implementation::Jellyfin(jellyfin) = &self.implementation {
             return jellyfin.read_track_metadata(track).await;
         }
-        let (path, format) = self
-            .metadata_track_path(database, source, &track)
-            .await
-            .map_err(|error| crate::SourceMetadataError::Write(error.to_string()))?
-            .ok_or(crate::SourceMetadataError::Unavailable)?;
+        let (path, format) = self.metadata_file_target(database, source, &track).await?;
+        if matches!(self.implementation, Implementation::OpenSubsonic(_))
+            && !self.mapped_metadata_ready().await
+        {
+            return Err(crate::SourceMetadataError::Unavailable);
+        }
         let mut metadata = crate::local::read_track_metadata(track_key, &path, format.as_deref())?;
         if metadata.values.musicbrainz_recording_id.is_none()
             && track.musicbrainz_recording_id.is_some()
@@ -853,11 +949,13 @@ impl Source {
                     .await
             }
             Implementation::OpenSubsonic(_) => {
+                let metadata = self
+                    .read_local_album_metadata(database, source, album)
+                    .await?;
                 if !self.mapped_metadata_ready().await {
                     return Err(crate::SourceMetadataError::Unavailable);
                 }
-                self.read_local_album_metadata(database, source, album)
-                    .await
+                Ok(metadata)
             }
         }
     }
@@ -882,11 +980,13 @@ impl Source {
                     .await
             }
             Implementation::OpenSubsonic(_) => {
+                let metadata = self
+                    .read_local_artist_metadata(database, source, artist)
+                    .await?;
                 if !self.mapped_metadata_ready().await {
                     return Err(crate::SourceMetadataError::Unavailable);
                 }
-                self.read_local_artist_metadata(database, source, artist)
-                    .await
+                Ok(metadata)
             }
         }
     }
@@ -910,28 +1010,6 @@ impl Source {
             .ok_or_else(|| "Album is no longer current".to_string())?;
         jellyfin
             .identify_album_metadata(&album.object_id, values)
-            .await
-    }
-
-    pub async fn identify_track_metadata(
-        &self,
-        database: &Database,
-        source: library::SourceKey,
-        track_key: library::TrackKey,
-        values: &crate::TrackMetadataValues,
-    ) -> Result<Option<(crate::TrackMetadataValues, String)>, String> {
-        let Implementation::Jellyfin(jellyfin) = &self.implementation else {
-            return Ok(None);
-        };
-        let cancellation = library::ReadCancellation::new();
-        let track = database
-            .track_rows(source, &[track_key], &cancellation)
-            .await
-            .map_err(|error| error.to_string())?
-            .pop()
-            .ok_or_else(|| "Track is no longer current".to_string())?;
-        jellyfin
-            .identify_track_metadata(&track.object_id, values)
             .await
     }
 
@@ -1221,11 +1299,7 @@ impl Source {
         expected_revision: &str,
         edit: &crate::TrackMetadataEdit,
     ) -> Result<(), crate::SourceMetadataError> {
-        let (path, format) = self
-            .metadata_track_path(database, source, track)
-            .await
-            .map_err(|error| crate::SourceMetadataError::Write(error.to_string()))?
-            .ok_or(crate::SourceMetadataError::Unavailable)?;
+        let (path, format) = self.metadata_file_target(database, source, track).await?;
         crate::local::metadata::write_track(&path, format.as_deref(), expected_revision, edit)?;
         match &self.implementation {
             Implementation::Local(local) => {
@@ -1472,11 +1546,7 @@ impl Source {
                 return Err(crate::SourceMetadataError::Unavailable);
             }
             for row in rows {
-                let (path, format) = self
-                    .metadata_track_path(database, source, &row)
-                    .await
-                    .map_err(|error| crate::SourceMetadataError::Write(error.to_string()))?
-                    .ok_or(crate::SourceMetadataError::Unavailable)?;
+                let (path, format) = self.metadata_file_target(database, source, &row).await?;
                 if !crate::local::metadata_file_available(&path, format.as_deref()) {
                     return Err(crate::SourceMetadataError::Unavailable);
                 }
@@ -1521,6 +1591,7 @@ impl Source {
                     track.duration_millis,
                 )
                 .await?
+                .filter(|access| access.origin == library::LocalAccessOrigin::Mapping)
         {
             return Ok(Some((
                 PathBuf::from(access.path),
@@ -1528,6 +1599,34 @@ impl Source {
             )));
         }
         Ok(None)
+    }
+
+    async fn metadata_file_target(
+        &self,
+        database: &Database,
+        source: library::SourceKey,
+        track: &library::TrackRow,
+    ) -> Result<(PathBuf, Option<String>), crate::SourceMetadataError> {
+        if let Some(target) = self
+            .metadata_track_path(database, source, track)
+            .await
+            .map_err(|error| crate::SourceMetadataError::Write(error.to_string()))?
+        {
+            return Ok(target);
+        }
+        if matches!(self.implementation, Implementation::OpenSubsonic(_))
+            && let Some(source_path) = database
+                .mapping_track_source_path(
+                    source,
+                    track.track_key,
+                    &library::ReadCancellation::new(),
+                )
+                .await
+                .map_err(metadata_database_error)?
+        {
+            return Err(crate::SourceMetadataError::LocalAccessRequired { source_path });
+        }
+        Err(crate::SourceMetadataError::Unavailable)
     }
 
     pub async fn create_playlist(
@@ -1792,15 +1891,11 @@ impl Source {
         }
     }
 
-    pub async fn lyrics(
-        &self,
-        track_object_id: &str,
-        search: crate::LyricsSearch,
-    ) -> SourceResult<Option<crate::NativeLyrics>> {
+    pub async fn lyrics(&self, track_object_id: &str) -> SourceResult<Option<crate::NativeLyrics>> {
         match &self.implementation {
             Implementation::Local(_) => Ok(None),
-            Implementation::Jellyfin(source) => source.lyrics(track_object_id, search).await,
-            Implementation::OpenSubsonic(source) => source.lyrics(track_object_id, search).await,
+            Implementation::Jellyfin(source) => source.lyrics(track_object_id).await,
+            Implementation::OpenSubsonic(source) => source.lyrics(track_object_id).await,
         }
     }
 

--- a/crates/sources/src/subsonic/client.rs
+++ b/crates/sources/src/subsonic/client.rs
@@ -449,11 +449,7 @@ impl SubsonicSource {
 }
 
 impl SubsonicSource {
-    pub(crate) async fn lyrics(
-        &self,
-        track_id: &str,
-        _search: LyricsSearch,
-    ) -> SourceResult<Option<NativeLyrics>> {
+    pub(crate) async fn lyrics(&self, track_id: &str) -> SourceResult<Option<NativeLyrics>> {
         let extensions: OpenSubsonicExtensionsBody = self
             .get_json("getOpenSubsonicExtensions", &[])
             .await

--- a/crates/sources/src/subsonic/mod.rs
+++ b/crates/sources/src/subsonic/mod.rs
@@ -1,10 +1,10 @@
 use crate::config::{decode_provider_payload, require_payload_version};
 use crate::policy::{raw_item_id, stable_hash, u16_from_option};
 use crate::{
-    ConnectedSource, CredentialHostInput, CredentialSettingsInput, ImageBytes, LyricsSearch,
-    NativeLyricAgent, NativeLyricAgentRole, NativeLyricCue, NativeLyricCueLine, NativeLyricLine,
-    NativeLyrics, NativeLyricsDocument, NativeLyricsRole, SourceConfiguration, SourceEditResult,
-    SourceError, SourceResult,
+    ConnectedSource, CredentialHostInput, CredentialSettingsInput, ImageBytes, NativeLyricAgent,
+    NativeLyricAgentRole, NativeLyricCue, NativeLyricCueLine, NativeLyricLine, NativeLyrics,
+    NativeLyricsDocument, NativeLyricsRole, SourceConfiguration, SourceEditResult, SourceError,
+    SourceResult,
 };
 use playback::{ResolvedStream, SourceReportFact, SourceReportPhase, StreamQuality, StreamRequest};
 use reqwest::{Client, Url};

--- a/crates/ui/src/application/style.rs
+++ b/crates/ui/src/application/style.rs
@@ -111,6 +111,7 @@ impl ApplicationAppearance {
             .load_from_string(&appearance_override_css(
                 settings.theme_preference,
                 settings.accent_preference,
+                &settings.lyrics,
             ));
     }
 }
@@ -123,17 +124,17 @@ fn color_scheme(preference: ThemePreference) -> adw::ColorScheme {
     }
 }
 
-fn appearance_override_css(theme: ThemePreference, accent: AccentPreference) -> String {
+fn appearance_override_css(
+    theme: ThemePreference,
+    accent: AccentPreference,
+    lyrics: &lyrics::Settings,
+) -> String {
     let surface_tokens = match theme {
         ThemePreference::System => "",
         ThemePreference::Light => LIGHT_SURFACE_TOKENS,
         ThemePreference::Dark => DARK_SURFACE_TOKENS,
     };
     let accent_color = accent_color(accent);
-    if surface_tokens.is_empty() && accent_color.is_none() {
-        return String::new();
-    }
-
     let mut css = String::from(":root {\n");
     css.push_str(surface_tokens);
     if let Some(color) = accent_color {
@@ -144,7 +145,24 @@ fn appearance_override_css(theme: ThemePreference, accent: AccentPreference) -> 
             "  --accent-color: oklab(from var(--accent-bg-color) var(--standalone-color-oklab));\n",
         );
     }
+    if let Some(color) = lyrics.lyrics_highlight_color.as_deref() {
+        css.push_str("  --lyrics-highlight-color: ");
+        css.push_str(color);
+        css.push_str(";\n");
+    }
     css.push_str("}\n");
+    let selectors = ".lyrics-line, .lyrics-furigana, .lyrics-romanization, .lyrics-reading-surface, .lyrics-cue";
+    if let Some(family) = lyrics.lyrics_font_family.as_deref() {
+        css.push_str(selectors);
+        css.push_str(" {\n");
+        css.push_str("  font-family: '");
+        css.push_str(&family.replace('\\', "\\\\").replace('\'', "\\'"));
+        css.push_str("', sans-serif;\n");
+        css.push_str("}\n");
+    }
+    if let Some(size) = lyrics.lyrics_font_size {
+        css.push_str(&format!(".lyrics-line {{ font-size: {size}px; }}\n"));
+    }
     css
 }
 
@@ -167,6 +185,10 @@ fn accent_color(preference: AccentPreference) -> Option<&'static str> {
 mod tests {
     use super::*;
 
+    fn css(theme: ThemePreference, accent: AccentPreference) -> String {
+        appearance_override_css(theme, accent, &lyrics::Settings::default())
+    }
+
     #[test]
     fn theme_preferences_map_to_explicit_application_color_schemes() {
         assert_eq!(
@@ -184,21 +206,21 @@ mod tests {
     }
 
     #[test]
-    fn system_appearance_does_not_override_user_theme_tokens() {
-        assert_eq!(
-            appearance_override_css(ThemePreference::System, AccentPreference::System),
-            ""
-        );
+    fn system_appearance_only_overrides_lyrics_tokens() {
+        let css = css(ThemePreference::System, AccentPreference::System);
+        assert!(!css.contains("--lyrics-highlight-color"));
+        assert!(!css.contains("--window-bg-color"));
+        assert!(!css.contains("--accent-bg-color"));
     }
 
     #[test]
     fn explicit_color_schemes_override_surface_tokens_only() {
-        let light = appearance_override_css(ThemePreference::Light, AccentPreference::System);
+        let light = css(ThemePreference::Light, AccentPreference::System);
         assert!(light.contains("--window-bg-color: #fafafb"));
         assert!(light.contains("--view-bg-color: #ffffff"));
         assert!(!light.contains("--accent-bg-color"));
 
-        let dark = appearance_override_css(ThemePreference::Dark, AccentPreference::System);
+        let dark = css(ThemePreference::Dark, AccentPreference::System);
         assert!(dark.contains("--window-bg-color: #222226"));
         assert!(dark.contains("--view-bg-color: #1d1d20"));
         assert!(!dark.contains("--accent-bg-color"));
@@ -218,7 +240,7 @@ mod tests {
             (AccentPreference::Slate, "#6f8396"),
         ];
         for (preference, color) in expected {
-            let css = appearance_override_css(ThemePreference::System, preference);
+            let css = css(ThemePreference::System, preference);
             assert!(css.contains(&format!("--accent-bg-color: {color}")));
             assert!(css.contains("--accent-fg-color: #ffffff"));
             assert!(css.contains("--accent-color: oklab("));

--- a/crates/ui/src/player/lyrics/panel.rs
+++ b/crates/ui/src/player/lyrics/panel.rs
@@ -12,8 +12,8 @@ use adw::prelude::*;
 use gtk::glib;
 use localization::result_count_text;
 use localization::tr;
-use lyrics::{LyricsSearchResult, release_japanese_reader};
-use std::cell::RefCell;
+use lyrics::{CurrentLyrics, CurrentLyricsContent, LyricsSearchResult, release_japanese_reader};
+use std::cell::{Cell, RefCell};
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::time::Duration;
@@ -23,6 +23,41 @@ const LYRICS_SEARCH_DEBOUNCE_MILLIS: u64 = 600;
 
 fn take_dirty_lyrics_pane(dirty: &std::cell::Cell<bool>, visible: bool) -> bool {
     visible && dirty.replace(false)
+}
+
+fn highlight_lrc_timestamps(buffer: &gtk::TextBuffer) {
+    let Some(line_time) = buffer.tag_table().lookup("line-time") else {
+        return;
+    };
+    let Some(word_time) = buffer.tag_table().lookup("word-time") else {
+        return;
+    };
+    let (start, end) = buffer.bounds();
+    buffer.remove_tag(&line_time, &start, &end);
+    buffer.remove_tag(&word_time, &start, &end);
+    let mut cursor = start;
+    while !cursor.is_end() {
+        let open = cursor.char();
+        if !matches!(open, '[' | '<') {
+            cursor.forward_char();
+            continue;
+        }
+        let tag_start = cursor;
+        cursor.forward_char();
+        let close = if open == '[' { ']' } else { '>' };
+        while !cursor.is_end() {
+            let character = cursor.char();
+            cursor.forward_char();
+            if matches!(character, '\n') || character == close {
+                break;
+            }
+        }
+        buffer.apply_tag(
+            if open == '[' { &line_time } else { &word_time },
+            &tag_start,
+            &cursor,
+        );
+    }
 }
 
 impl Shell {
@@ -100,11 +135,16 @@ impl Shell {
                 .can_suppress_auto_lyrics(settings.private_mode, track_id, lyrics_origin)
         });
         let lyrics_available = lyrics.is_some();
+        let lyrics_editable = lyrics_available
+            && current_media
+                .as_ref()
+                .is_some_and(|media_id| self.products.lyrics.current_writable(media_id));
         let show_furigana = settings.lyrics.show_furigana;
         let show_romanization = settings.lyrics.show_romanization;
-        let word_by_word_highlighting = settings.lyrics.word_by_word_highlighting;
+        let word_by_word_highlighting = settings.lyrics.karaoke_mode;
         drop(settings);
         pane.set_save_action(&tr("Save Lyrics"), lyrics_available);
+        pane.set_edit_action(lyrics_editable);
         pane.set_search_action(&search_label, search_enabled);
         pane.set_clear_auto_search_action(
             &tr("Clear fetched lyrics for this track"),
@@ -183,6 +223,186 @@ impl Shell {
                 .lyrics
                 .save_current(media_id, offset_millis, path);
         });
+    }
+
+    pub(crate) fn present_lyrics_edit_dialog(self: &Rc<Self>) {
+        let Some(media_id) = current_playback_media_id(self.selected_playback().as_deref()) else {
+            return;
+        };
+        let Some(lyrics) = self.selected_lyrics() else {
+            return;
+        };
+        let projection = lyrics.projection.borrow();
+        let CurrentLyrics::Ready {
+            content: Some(CurrentLyricsContent::Document { document, .. }),
+            ..
+        } = &*projection
+        else {
+            return;
+        };
+        let offset_millis = lyrics.offset_millis.get();
+        let content = lyrics::lyrics_to_lrc_text(document, offset_millis);
+        drop(projection);
+        drop(lyrics);
+
+        let dialog = adw::Dialog::builder()
+            .title(tr("Edit Lyrics"))
+            .content_width(560)
+            .content_height(600)
+            .build();
+        let toolbar = adw::ToolbarView::new();
+        toolbar.add_top_bar(&adw::HeaderBar::new());
+        let body = gtk::Box::new(gtk::Orientation::Vertical, 12);
+        body.set_margin_top(16);
+        body.set_margin_bottom(16);
+        body.set_margin_start(16);
+        body.set_margin_end(16);
+        let editor = gtk::TextView::new();
+        editor.set_monospace(true);
+        editor.set_wrap_mode(gtk::WrapMode::WordChar);
+        let buffer = editor.buffer();
+        buffer.create_tag(Some("line-time"), &[("foreground", &"#e8962c")]);
+        buffer.create_tag(Some("word-time"), &[("foreground", &"#8ab4f8")]);
+        buffer.set_text(&content);
+        highlight_lrc_timestamps(&buffer);
+
+        let offset = Rc::new(Cell::new(offset_millis));
+        let offset_controls = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+        offset_controls.set_halign(gtk::Align::Center);
+        let offset_decrease_100 = gtk::Button::with_label("-100 ms");
+        let offset_decrease_50 = gtk::Button::with_label("-50 ms");
+        let offset_entry = gtk::Entry::new();
+        offset_entry.set_text(&format!("{offset_millis} ms"));
+        gtk::prelude::EditableExt::set_alignment(&offset_entry, 0.5);
+        offset_entry.set_width_chars(6);
+        offset_entry.set_max_width_chars(9);
+        offset_entry.set_max_length(24);
+        offset_entry.set_tooltip_text(Some(&tr("Lyrics offset (ms)")));
+        let offset_increase_50 = gtk::Button::with_label("+50 ms");
+        let offset_increase_100 = gtk::Button::with_label("+100 ms");
+        offset_controls.append(&offset_decrease_100);
+        offset_controls.append(&offset_decrease_50);
+        offset_controls.append(&offset_entry);
+        offset_controls.append(&offset_increase_50);
+        offset_controls.append(&offset_increase_100);
+        body.append(&offset_controls);
+
+        let apply_offset: Rc<dyn Fn(i64)> = Rc::new({
+            let offset = Rc::clone(&offset);
+            let entry = offset_entry.downgrade();
+            let buffer = buffer.clone();
+            let shell = Rc::downgrade(self);
+            move |value| {
+                let previous = offset.replace(value);
+                let delta = value.saturating_sub(previous);
+                if delta != 0 {
+                    let (start, end) = buffer.bounds();
+                    let text = buffer.text(&start, &end, false);
+                    buffer.set_text(&lyrics::shift_lrc_text_timestamps(&text, delta));
+                    if let Some(shell) = shell.upgrade() {
+                        shell.set_lyrics_offset_from_text(&value.to_string());
+                    }
+                }
+                if let Some(entry) = entry.upgrade() {
+                    entry.set_text(&format!("{value} ms"));
+                }
+            }
+        });
+        let commit_offset: Rc<dyn Fn()> = Rc::new({
+            let offset = Rc::clone(&offset);
+            let entry = offset_entry.downgrade();
+            let apply_offset = Rc::clone(&apply_offset);
+            move || {
+                let Some(entry) = entry.upgrade() else {
+                    return;
+                };
+                match super::state::parse_lyrics_offset_millis(&entry.text()) {
+                    Some(value) => apply_offset(value),
+                    None => entry.set_text(&format!("{} ms", offset.get())),
+                }
+            }
+        });
+        for (button, delta) in [
+            (&offset_decrease_100, -100),
+            (&offset_decrease_50, -50),
+            (&offset_increase_50, 50),
+            (&offset_increase_100, 100),
+        ] {
+            button.connect_clicked({
+                let offset = Rc::clone(&offset);
+                let apply_offset = Rc::clone(&apply_offset);
+                let commit_offset = Rc::clone(&commit_offset);
+                move |_| {
+                    commit_offset();
+                    apply_offset(offset.get().saturating_add(delta));
+                }
+            });
+        }
+        offset_entry.connect_activate({
+            let commit_offset = Rc::clone(&commit_offset);
+            move |_| commit_offset()
+        });
+        let offset_focus = gtk::EventControllerFocus::new();
+        offset_focus.connect_leave({
+            let commit_offset = Rc::clone(&commit_offset);
+            move |_| commit_offset()
+        });
+        offset_entry.add_controller(offset_focus);
+
+        let scroller = gtk::ScrolledWindow::builder()
+            .child(&editor)
+            .vexpand(true)
+            .build();
+        body.append(&scroller);
+
+        let actions = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+        actions.set_halign(gtk::Align::End);
+        let cancel = gtk::Button::with_label(&tr("Cancel"));
+        let save = gtk::Button::with_label(&tr("Save"));
+        save.add_css_class("suggested-action");
+        actions.append(&cancel);
+        actions.append(&save);
+        body.append(&actions);
+        toolbar.set_content(Some(&body));
+        dialog.set_child(Some(&toolbar));
+
+        let committed = Rc::new(Cell::new(false));
+        let close = dialog.clone();
+        cancel.connect_clicked(move |_| {
+            close.close();
+        });
+        let restore_shell = Rc::downgrade(self);
+        let restore_committed = Rc::clone(&committed);
+        let restore_media = media_id.clone();
+        dialog.connect_closed(move |_| {
+            if !restore_committed.get()
+                && let Some(shell) = restore_shell.upgrade()
+                && current_playback_media_id(shell.selected_playback().as_deref())
+                    == Some(restore_media.clone())
+            {
+                shell.set_lyrics_offset_from_text(&offset_millis.to_string());
+            }
+        });
+        let save_for_text = save.clone();
+        buffer.connect_changed(move |buffer| {
+            highlight_lrc_timestamps(buffer);
+            let (start, end) = buffer.bounds();
+            save_for_text.set_sensitive(!buffer.text(&start, &end, false).trim().is_empty());
+        });
+        let shell = Rc::clone(self);
+        let close = dialog.clone();
+        save.connect_clicked(move |_| {
+            commit_offset();
+            let (start, end) = buffer.bounds();
+            let text = buffer.text(&start, &end, false).to_string();
+            committed.set(true);
+            shell
+                .products
+                .lyrics
+                .update_lyrics_text(media_id.clone(), text);
+            close.close();
+        });
+        present_light_dismiss_dialog(&dialog, &self.chrome.window);
     }
     pub(crate) fn present_lyrics_search_dialog(self: &Rc<Self>) {
         let Some(lyrics) = self.selected_lyrics() else {

--- a/crates/ui/src/player/lyrics/search.rs
+++ b/crates/ui/src/player/lyrics/search.rs
@@ -35,6 +35,12 @@ pub(crate) fn connect_lyrics_search_controls(shell: &Rc<Shell>) {
             }
         });
         let weak = Rc::downgrade(shell);
+        pane.connect_edit_clicked(move || {
+            if let Some(shell) = weak.upgrade() {
+                shell.present_lyrics_edit_dialog();
+            }
+        });
+        let weak = Rc::downgrade(shell);
         pane.connect_search_clicked(move || {
             let Some(shell) = weak.upgrade() else {
                 return;

--- a/crates/ui/src/player/lyrics/settings.rs
+++ b/crates/ui/src/player/lyrics/settings.rs
@@ -6,13 +6,13 @@ use localization::{
 };
 use lyrics::ExternalLyricsProvider;
 
+use crate::player::state::current_playback_track;
 use crate::preferences::dialogs::popup::present_light_dismiss_dialog;
 use crate::shell::Shell;
 
 #[derive(Clone)]
 pub(crate) struct LyricsSettingsDialog {
     pub(crate) dialog: adw::PreferencesDialog,
-    word_by_word_highlighting: adw::SwitchRow,
 }
 
 pub(crate) fn connect_lyrics_settings_controls(shell: &Rc<Shell>) {
@@ -39,7 +39,7 @@ fn present_lyrics_settings_dialog(shell: &Rc<Shell>) {
     }
     drop(lyrics);
 
-    let (page, word_by_word_highlighting) = build_lyrics_settings(shell);
+    let page = build_lyrics_settings(shell);
     let dialog = adw::PreferencesDialog::builder()
         .title(tr("Lyrics settings"))
         .search_enabled(false)
@@ -49,7 +49,6 @@ fn present_lyrics_settings_dialog(shell: &Rc<Shell>) {
     dialog.add(&page);
     let settings_dialog = LyricsSettingsDialog {
         dialog: dialog.clone(),
-        word_by_word_highlighting,
     };
     if let Some(lyrics) = shell.selected_lyrics() {
         lyrics.settings_dialog.replace(Some(settings_dialog));
@@ -64,18 +63,7 @@ fn present_lyrics_settings_dialog(shell: &Rc<Shell>) {
     present_light_dismiss_dialog(&dialog, &shell.chrome.window);
 }
 
-pub(crate) fn refresh_word_highlighting_availability(shell: &Rc<Shell>) {
-    let Some(lyrics) = shell.selected_lyrics() else {
-        return;
-    };
-    if let Some(settings_dialog) = lyrics.settings_dialog.borrow().as_ref() {
-        settings_dialog
-            .word_by_word_highlighting
-            .set_sensitive(shell.visible_lyrics_have_word_timing());
-    }
-}
-
-fn build_lyrics_settings(shell: &Rc<Shell>) -> (adw::PreferencesPage, adw::SwitchRow) {
+fn build_lyrics_settings(shell: &Rc<Shell>) -> adw::PreferencesPage {
     let settings = shell.settings.current.borrow().lyrics.clone();
     let page = adw::PreferencesPage::builder()
         .title(tr("Lyrics settings"))
@@ -99,17 +87,48 @@ fn build_lyrics_settings(shell: &Rc<Shell>) -> (adw::PreferencesPage, adw::Switc
     });
     sources.add(&prefer_server);
 
+    let save_fetched = switch_row(msgid("Save Lyrics"), settings.save_fetched_lyrics);
+    save_fetched.set_subtitle(&tr(msgid("Saves lyrics to your source")));
+    save_fetched.set_sensitive(settings.external_lyrics_enabled);
+    let save_shell = Rc::clone(shell);
+    save_fetched.connect_active_notify(move |row| {
+        let enabled = row.is_active();
+        if !save_shell.set_save_fetched_lyrics(enabled) {
+            return;
+        }
+        if !enabled
+            || !selected_source_uses_mapped_metadata(&save_shell)
+            || selected_source_has_local_mapping(&save_shell)
+        {
+            return;
+        }
+        let Some(track) = current_playback_track(save_shell.selected_playback().as_deref())
+            .and_then(|track| track.track_key)
+        else {
+            save_shell.show_feedback_toast(tr(msgid("Metadata editing is no longer available")));
+            return;
+        };
+        crate::preferences::dialogs::metadata::ensure_track_metadata_available(
+            &save_shell,
+            track,
+            Rc::new(|| {}),
+        );
+    });
+    sources.add(&save_fetched);
+
     let provider_rows = Rc::new(RefCell::new(Vec::new()));
     populate_provider_rows(shell, &sources, &provider_rows);
     let external_shell = Rc::clone(shell);
     let external_sources = sources.downgrade();
     let external_provider_rows = Rc::clone(&provider_rows);
     let external_prefer_server = prefer_server.clone();
+    let external_save_fetched = save_fetched.clone();
     external.connect_active_notify(move |row| {
         if !external_shell.set_external_lyrics_enabled(row.is_active()) {
             return;
         }
         external_prefer_server.set_sensitive(row.is_active());
+        external_save_fetched.set_sensitive(row.is_active());
         let Some(sources) = external_sources.upgrade() else {
             return;
         };
@@ -176,21 +195,155 @@ fn build_lyrics_settings(shell: &Rc<Shell>) -> (adw::PreferencesPage, adw::Switc
     page.add(&language_and_readings);
 
     let playback = adw::PreferencesGroup::builder()
-        .title(tr("Playback"))
+        .title(tr("Karaoke Playback"))
         .build();
     let karaoke = adw::SwitchRow::builder()
         .title(tr(msgid("Karaoke mode")))
-        .subtitle(tr(msgid("Requires OpenSubsonic songLyrics v2")))
-        .active(settings.word_by_word_highlighting)
+        .subtitle(tr(msgid(
+            "Uses available karaoke lyrics or fetches them from the internet",
+        )))
+        .active(settings.karaoke_mode)
         .build();
-    karaoke.set_sensitive(shell.visible_lyrics_have_word_timing());
     let karaoke_shell = Rc::clone(shell);
     karaoke.connect_active_notify(move |row| {
-        karaoke_shell.set_lyrics_word_highlighting(row.is_active());
+        karaoke_shell.set_lyrics_karaoke_mode(row.is_active());
     });
     playback.add(&karaoke);
+    let highlight_color = adw::ActionRow::builder()
+        .title(tr("Karaoke highlight color"))
+        .subtitle(tr("Color for the active word during playback"))
+        .build();
+    let theme_accent = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    theme_accent.add_css_class("lyrics-theme-accent-probe");
+    theme_accent.set_opacity(0.0);
+    theme_accent.set_can_target(false);
+    let preview = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    preview.add_css_class("lyrics-highlight-swatch");
+    let color_button = gtk::Button::builder()
+        .child(&preview)
+        .css_classes(["flat"])
+        .width_request(32)
+        .height_request(32)
+        .valign(gtk::Align::Center)
+        .build();
+    let color_shell = Rc::clone(shell);
+    let default_accent = theme_accent.clone();
+    color_button.connect_clicked(move |_| {
+        let default_color = default_accent.color();
+        let initial = color_shell
+            .settings
+            .current
+            .borrow()
+            .lyrics
+            .lyrics_highlight_color
+            .as_deref()
+            .and_then(|color| gtk::gdk::RGBA::parse(color).ok())
+            .unwrap_or(default_color);
+        present_lyrics_color_chooser(
+            &color_shell,
+            &color_shell.chrome.window,
+            initial,
+            default_accent.clone().upcast(),
+        );
+    });
+    highlight_color.add_suffix(&theme_accent);
+    highlight_color.add_suffix(&color_button);
+    highlight_color.set_activatable_widget(Some(&color_button));
+    playback.add(&highlight_color);
     page.add(&playback);
-    (page, karaoke)
+
+    let typography = adw::PreferencesGroup::builder()
+        .title(tr("Typography"))
+        .build();
+    let font_families = Rc::new(system_font_families(&shell.chrome.window));
+    let mut font_titles = vec![tr("Default")];
+    font_titles.extend(font_families.iter().cloned());
+    let font_title_refs = font_titles.iter().map(String::as_str).collect::<Vec<_>>();
+    let font = adw::ComboRow::builder()
+        .title(tr("Font family"))
+        .enable_search(true)
+        .model(&gtk::StringList::new(&font_title_refs))
+        .selected(
+            settings
+                .lyrics_font_family
+                .as_ref()
+                .and_then(|selected| font_families.iter().position(|family| family == selected))
+                .map_or(0, |index| index as u32 + 1),
+        )
+        .build();
+    let font_shell = Rc::clone(shell);
+    let selected_families = Rc::clone(&font_families);
+    font.connect_selected_notify(move |row| {
+        let family = row
+            .selected()
+            .checked_sub(1)
+            .and_then(|index| selected_families.get(index as usize))
+            .cloned();
+        font_shell.set_lyrics_font_family(family);
+    });
+    typography.add(&font);
+    let size = adw::SpinRow::builder()
+        .title(tr("Font size (px)"))
+        .adjustment(
+            &gtk::Adjustment::builder()
+                .lower(12.0)
+                .upper(28.0)
+                .step_increment(1.0)
+                .value(f64::from(settings.lyrics_font_size.unwrap_or(19)))
+                .build(),
+        )
+        .digits(0)
+        .build();
+    let size_shell = Rc::clone(shell);
+    size.connect_value_notify(move |row| {
+        let size = row.value().round() as u16;
+        size_shell.set_lyrics_font_size((size != 19).then_some(size));
+    });
+    typography.add(&size);
+    page.add(&typography);
+    page
+}
+
+fn selected_source_uses_mapped_metadata(shell: &Shell) -> bool {
+    let Some(source_id) = shell
+        .selected_library()
+        .as_deref()
+        .map(|selected| selected.artwork.source_id.clone())
+    else {
+        return false;
+    };
+    shell
+        .source
+        .configured
+        .borrow()
+        .sources
+        .iter()
+        .any(|source| {
+            source.id == source_id && matches!(source.kind.as_str(), "navidrome" | "subsonic")
+        })
+}
+
+fn selected_source_has_local_mapping(shell: &Shell) -> bool {
+    let Some(source_id) = shell
+        .selected_library()
+        .as_deref()
+        .map(|selected| selected.artwork.source_id.clone())
+    else {
+        return false;
+    };
+    shell
+        .source
+        .configured
+        .borrow()
+        .local_access
+        .iter()
+        .find(|summary| summary.source_id == source_id)
+        .is_some_and(|summary| {
+            summary.status.direct_match_count
+                + summary.status.prefix_match_count
+                + summary.status.metadata_match_count
+                > 0
+        })
 }
 
 fn populate_provider_rows(
@@ -332,6 +485,100 @@ fn reading_switch_row(title: &str, active: bool) -> adw::SwitchRow {
         .build()
 }
 
+fn system_font_families(widget: &impl IsA<gtk::Widget>) -> Vec<String> {
+    let Some(font_map) = widget.pango_context().font_map() else {
+        return Vec::new();
+    };
+    let mut families = font_map
+        .list_families()
+        .into_iter()
+        .map(|family| family.name().to_string())
+        .collect::<Vec<_>>();
+    families.sort_unstable();
+    families.dedup();
+    families
+}
+
+#[allow(deprecated)]
+fn present_lyrics_color_chooser(
+    shell: &Rc<Shell>,
+    parent: &impl IsA<gtk::Window>,
+    initial: gtk::gdk::RGBA,
+    default_probe: gtk::Widget,
+) {
+    let chooser = Rc::new(RefCell::new(lyrics_color_chooser(&initial)));
+
+    let cancel = gtk::Button::with_label(&tr("Cancel"));
+    let default = gtk::Button::with_label(&tr("Default"));
+    let select = gtk::Button::with_label(&tr("Save"));
+    select.add_css_class("suggested-action");
+    let header = adw::HeaderBar::new();
+    header.set_show_start_title_buttons(false);
+    header.set_show_end_title_buttons(false);
+    header.set_title_widget(Some(&adw::WindowTitle::new(
+        &tr("Karaoke highlight color"),
+        "",
+    )));
+    header.pack_start(&cancel);
+    header.pack_end(&select);
+    header.pack_end(&default);
+
+    let body = gtk::Box::new(gtk::Orientation::Vertical, 0);
+    body.set_vexpand(true);
+    body.append(&*chooser.borrow());
+    let toolbar = adw::ToolbarView::new();
+    toolbar.add_top_bar(&header);
+    toolbar.set_content(Some(&body));
+    let dialog = adw::Window::builder()
+        .title(tr("Karaoke highlight color"))
+        .default_width(520)
+        .default_height(420)
+        .modal(true)
+        .resizable(false)
+        .transient_for(parent)
+        .content(&toolbar)
+        .build();
+
+    let close = dialog.clone();
+    cancel.connect_clicked(move |_| close.close());
+    let default_chooser = Rc::clone(&chooser);
+    let default_body = body.clone();
+    default.connect_clicked(move |_| {
+        let replacement = lyrics_color_chooser(&default_probe.color());
+        default_body.remove(&*default_chooser.borrow());
+        default_body.append(&replacement);
+        default_chooser.replace(replacement);
+    });
+    let shell = Rc::clone(shell);
+    let close = dialog.clone();
+    select.connect_clicked(move |_| {
+        let color = chooser.borrow().rgba();
+        shell.set_lyrics_highlight_color(Some(rgba_hex(&color)));
+        close.close();
+    });
+    dialog.present();
+}
+
+#[allow(deprecated)]
+fn lyrics_color_chooser(color: &gtk::gdk::RGBA) -> gtk::ColorChooserWidget {
+    let chooser = gtk::ColorChooserWidget::new();
+    chooser.set_show_editor(true);
+    chooser.set_use_alpha(false);
+    chooser.set_rgba(color);
+    chooser.set_hexpand(true);
+    chooser.set_vexpand(true);
+    chooser
+}
+
+fn rgba_hex(color: &gtk::gdk::RGBA) -> String {
+    format!(
+        "#{:02x}{:02x}{:02x}",
+        (color.red() * 255.0).round() as u8,
+        (color.green() * 255.0).round() as u8,
+        (color.blue() * 255.0).round() as u8,
+    )
+}
+
 fn small_icon_button(icon: &str, label: &str) -> gtk::Button {
     let button = gtk::Button::from_icon_name(icon);
     button.add_css_class("flat");
@@ -359,6 +606,16 @@ impl Shell {
             settings.prefer_server_lyrics = enabled;
             true
         });
+    }
+
+    pub(crate) fn set_save_fetched_lyrics(self: &Rc<Self>, enabled: bool) -> bool {
+        self.update_lyrics_settings("save fetched lyrics setting", false, |settings| {
+            if settings.save_fetched_lyrics == enabled {
+                return false;
+            }
+            settings.save_fetched_lyrics = enabled;
+            true
+        })
     }
 
     pub(crate) fn set_external_lyrics_provider_enabled(
@@ -444,14 +701,54 @@ impl Shell {
         });
     }
 
-    pub(crate) fn set_lyrics_word_highlighting(self: &Rc<Self>, enabled: bool) {
+    pub(crate) fn set_lyrics_karaoke_mode(self: &Rc<Self>, enabled: bool) {
         self.update_lyrics_settings("lyrics karaoke setting", true, |settings| {
-            if settings.word_by_word_highlighting == enabled {
+            if settings.karaoke_mode == enabled {
                 return false;
             }
-            settings.word_by_word_highlighting = enabled;
+            settings.karaoke_mode = enabled;
             true
         });
+    }
+
+    pub(crate) fn set_lyrics_highlight_color(self: &Rc<Self>, color: Option<String>) {
+        if self.update_lyrics_settings("lyrics highlight color", true, |settings| {
+            if settings.lyrics_highlight_color == color {
+                return false;
+            }
+            settings.lyrics_highlight_color = color;
+            true
+        }) {
+            self.apply_lyrics_appearance();
+        }
+    }
+
+    pub(crate) fn set_lyrics_font_family(self: &Rc<Self>, family: Option<String>) {
+        if self.update_lyrics_settings("lyrics font family", false, |settings| {
+            if settings.lyrics_font_family == family {
+                return false;
+            }
+            settings.lyrics_font_family = family;
+            true
+        }) {
+            self.apply_lyrics_appearance();
+        }
+    }
+
+    pub(crate) fn set_lyrics_font_size(self: &Rc<Self>, size: Option<u16>) {
+        if self.update_lyrics_settings("lyrics font size", false, |settings| {
+            if settings.lyrics_font_size == size {
+                return false;
+            }
+            settings.lyrics_font_size = size;
+            true
+        }) {
+            self.apply_lyrics_appearance();
+        }
+    }
+
+    fn apply_lyrics_appearance(&self) {
+        self.appearance.apply(&self.settings.current.borrow());
     }
 
     fn update_lyrics_settings(

--- a/crates/ui/src/player/lyrics/state.rs
+++ b/crates/ui/src/player/lyrics/state.rs
@@ -138,11 +138,6 @@ impl Shell {
         )
     }
 
-    pub(crate) fn visible_lyrics_have_word_timing(&self) -> bool {
-        self.visible_lyrics()
-            .is_some_and(|document| document.has_word_timing())
-    }
-
     pub(crate) fn visible_lyrics_origin(&self) -> Option<LyricsOrigin> {
         let current_media = current_playback_media_id(self.selected_playback().as_deref());
         let lyrics = self.selected_lyrics()?;
@@ -219,7 +214,6 @@ impl Shell {
             lyrics.offset_millis.set(0);
         }
         *lyrics.projection.borrow_mut() = projection;
-        crate::player::lyrics::settings::refresh_word_highlighting_availability(self);
         self.render_lyrics_panel();
         if let Some(media_id) = media_id
             && let Some(dialog) = lyrics.search_dialog.borrow().as_ref()
@@ -442,7 +436,7 @@ fn playback_position_for_lyrics_position(position_millis: u64, offset_millis: i6
     }
 }
 
-fn parse_lyrics_offset_millis(value: &str) -> Option<i64> {
+pub(crate) fn parse_lyrics_offset_millis(value: &str) -> Option<i64> {
     let value = value.trim();
     let number = ["ms", "MS", "Ms", "mS"]
         .into_iter()

--- a/crates/ui/src/player/lyrics/timing.rs
+++ b/crates/ui/src/player/lyrics/timing.rs
@@ -1,4 +1,4 @@
-use super::view::next_lyrics_line_start_after;
+use super::view::next_lyrics_highlight_after;
 use crate::shell::Shell;
 use gtk::glib;
 use playback::{PlaybackOutput, TransportStatus};
@@ -29,10 +29,7 @@ impl Shell {
         }
 
         let Some(next_position_millis) = self.visible_lyrics().as_ref().and_then(|lyrics| {
-            next_lyrics_line_start_after(
-                &lyrics.lines,
-                self.lyrics_position_millis(position_millis),
-            )
+            next_lyrics_highlight_after(&lyrics.lines, self.lyrics_position_millis(position_millis))
         }) else {
             return;
         };

--- a/crates/ui/src/player/lyrics/view.rs
+++ b/crates/ui/src/player/lyrics/view.rs
@@ -6,7 +6,7 @@ use gtk::glib;
 use gtk::prelude::*;
 use localization::{msgid, tr};
 use lyrics::{
-    JapaneseReadingSegment, LyricsAgentRole, LyricsCue, LyricsDocument, LyricsLine,
+    JapaneseReadingSegment, LyricsAgentRole, LyricsCue, LyricsCueLine, LyricsDocument, LyricsLine,
     japanese_reading_for_language_options,
 };
 
@@ -20,6 +20,145 @@ const LYRICS_SCROLL_MS: u64 = 200;
 const LYRICS_USER_SCROLL_PAUSE_MS: u64 = 3_000;
 const LYRICS_SCROLL_READY_RETRY_MS: u64 = 32;
 const LYRICS_SCROLL_READY_RETRIES: u8 = 12;
+const KARAOKE_FRAME_MILLIS: u64 = 16;
+
+mod karaoke_text {
+    use std::cell::{Cell, RefCell};
+
+    use gtk::glib;
+    use gtk::prelude::*;
+    use gtk::subclass::prelude::*;
+
+    mod imp {
+        use super::*;
+
+        #[derive(Default)]
+        pub struct KaraokeText {
+            pub(super) labels: RefCell<Option<(gtk::Label, gtk::Label)>>,
+            pub(super) progress: Cell<f64>,
+        }
+
+        #[glib::object_subclass]
+        impl ObjectSubclass for KaraokeText {
+            const NAME: &'static str = "RufinLyricsKaraokeText";
+            type Type = super::KaraokeText;
+            type ParentType = gtk::Widget;
+        }
+
+        impl ObjectImpl for KaraokeText {
+            fn dispose(&self) {
+                if let Some((base, highlight)) = self.labels.take() {
+                    base.unparent();
+                    highlight.unparent();
+                }
+            }
+        }
+
+        impl WidgetImpl for KaraokeText {
+            fn request_mode(&self) -> gtk::SizeRequestMode {
+                self.labels
+                    .borrow()
+                    .as_ref()
+                    .map_or(gtk::SizeRequestMode::ConstantSize, |(base, _)| {
+                        base.request_mode()
+                    })
+            }
+
+            fn measure(
+                &self,
+                orientation: gtk::Orientation,
+                for_size: i32,
+            ) -> (i32, i32, i32, i32) {
+                self.labels
+                    .borrow()
+                    .as_ref()
+                    .map_or((0, 0, -1, -1), |(base, _)| {
+                        base.measure(orientation, for_size)
+                    })
+            }
+
+            fn size_allocate(&self, width: i32, height: i32, baseline: i32) {
+                if let Some((base, highlight)) = self.labels.borrow().as_ref() {
+                    base.allocate(width, height, baseline, None);
+                    highlight.allocate(width, height, baseline, None);
+                }
+            }
+
+            fn snapshot(&self, snapshot: &gtk::Snapshot) {
+                let labels = self.labels.borrow();
+                let Some((base, highlight)) = labels.as_ref() else {
+                    return;
+                };
+                self.obj().snapshot_child(base, snapshot);
+                let progress = self.progress.get().clamp(0.0, 1.0);
+                if progress <= 0.0 {
+                    return;
+                }
+                let width = self.obj().width() as f32;
+                let clip_width = width * progress as f32;
+                let clip_x = if self.obj().direction() == gtk::TextDirection::Rtl {
+                    width - clip_width
+                } else {
+                    0.0
+                };
+                snapshot.push_clip(&gtk::graphene::Rect::new(
+                    clip_x,
+                    0.0,
+                    clip_width,
+                    self.obj().height() as f32,
+                ));
+                self.obj().snapshot_child(highlight, snapshot);
+                snapshot.pop();
+            }
+        }
+    }
+
+    glib::wrapper! {
+        pub struct KaraokeText(ObjectSubclass<imp::KaraokeText>)
+            @extends gtk::Widget,
+            @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
+    }
+
+    impl KaraokeText {
+        pub(super) fn new(text: &str) -> Self {
+            let widget: Self = glib::Object::new();
+            let base = gtk::Label::new(Some(text));
+            let highlight = gtk::Label::new(Some(text));
+            highlight.add_css_class("lyrics-cue-sung");
+            highlight.set_accessible_role(gtk::AccessibleRole::Presentation);
+            base.set_parent(&widget);
+            highlight.set_parent(&widget);
+            widget.imp().labels.replace(Some((base, highlight)));
+            widget.set_accessible_role(gtk::AccessibleRole::Presentation);
+            widget
+        }
+
+        pub(super) fn add_text_class(&self, class: &str) {
+            self.add_css_class(class);
+            if let Some((base, highlight)) = self.imp().labels.borrow().as_ref() {
+                base.add_css_class(class);
+                highlight.add_css_class(class);
+            }
+        }
+
+        pub(super) fn set_progress(&self, progress: f64) {
+            let progress = progress.clamp(0.0, 1.0);
+            if (self.imp().progress.replace(progress) - progress).abs() > f64::EPSILON {
+                self.queue_draw();
+            }
+        }
+
+        pub(super) fn characters(&self) -> usize {
+            self.imp()
+                .labels
+                .borrow()
+                .as_ref()
+                .map_or(0, |(base, _)| base.text().chars().count())
+        }
+    }
+}
+
+use karaoke_text::KaraokeText;
 
 #[derive(Clone)]
 pub(crate) struct LyricsPane {
@@ -29,6 +168,7 @@ pub(crate) struct LyricsPane {
     save_button: gtk::Button,
     clear_auto_search_button: gtk::Button,
     search_button: gtk::Button,
+    edit_button: gtk::Button,
     settings_button: gtk::Button,
     offset_decrease_button: gtk::Button,
     offset_entry: gtk::Entry,
@@ -56,7 +196,14 @@ enum LyricsRowTrack {
 #[derive(Clone)]
 struct LyricsCueHighlight {
     cue: LyricsCue,
-    widget: gtk::Widget,
+    units: Vec<KaraokeUnit>,
+    parallels: Vec<KaraokeText>,
+}
+
+#[derive(Clone)]
+struct KaraokeUnit {
+    characters: usize,
+    texts: Vec<KaraokeText>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -93,6 +240,14 @@ impl LyricsPane {
         search_button.add_css_class("icon-button");
         search_button.add_css_class("flat");
         search_button.add_css_class("circular");
+        let edit_button = gtk::Button::from_icon_name("rufin-edit-symbolic");
+        edit_button.add_css_class("icon-button");
+        edit_button.add_css_class("flat");
+        edit_button.add_css_class("circular");
+        edit_button.set_focus_on_click(false);
+        let edit_label = tr("Edit lyrics");
+        edit_button.set_tooltip_text(Some(&edit_label));
+        edit_button.update_property(&[gtk::accessible::Property::Label(&edit_label)]);
         let settings_button = gtk::Button::from_icon_name("rufin-applications-system-symbolic");
         settings_button.add_css_class("icon-button");
         settings_button.add_css_class("flat");
@@ -108,6 +263,7 @@ impl LyricsPane {
         top_controls.set_valign(gtk::Align::Start);
         top_controls.append(&search_button);
         top_controls.append(&settings_button);
+        top_controls.append(&edit_button);
 
         let offset_decrease_button = lyrics_control_button("rufin-value-decrease-symbolic");
         let offset_entry = gtk::Entry::new();
@@ -155,6 +311,7 @@ impl LyricsPane {
             save_button,
             clear_auto_search_button,
             search_button,
+            edit_button,
             settings_button,
             offset_decrease_button,
             offset_entry,
@@ -178,6 +335,10 @@ impl LyricsPane {
 
     pub fn connect_settings_clicked(&self, open: impl Fn() + 'static) {
         self.settings_button.connect_clicked(move |_| open());
+    }
+
+    pub fn connect_edit_clicked(&self, edit: impl Fn() + 'static) {
+        self.edit_button.connect_clicked(move |_| edit());
     }
 
     pub fn connect_save_clicked(&self, save: impl Fn() + 'static) {
@@ -212,6 +373,11 @@ impl LyricsPane {
             .update_property(&[gtk::accessible::Property::Label(label)]);
         self.save_button.set_visible(enabled);
         self.save_button.set_sensitive(enabled);
+    }
+
+    pub fn set_edit_action(&self, enabled: bool) {
+        self.edit_button.set_visible(enabled);
+        self.edit_button.set_sensitive(enabled);
     }
 
     pub fn set_clear_auto_search_action(&self, label: &str, enabled: bool, visible: bool) {
@@ -412,6 +578,12 @@ impl LyricsPane {
                     }
                     let cue_line_widget = WrappingLine::new();
                     cue_line_widget.add_css_class("lyrics-line");
+                    let romanization_line = show_romanization.then(|| {
+                        let line = WrappingLine::new();
+                        line.add_css_class("lyrics-line");
+                        line.add_css_class("lyrics-romanization");
+                        line
+                    });
                     if cue_line.cues.is_empty() {
                         cue_line_widget.append(&lyrics_reading_unit(
                             &cue_line.text,
@@ -420,7 +592,7 @@ impl LyricsPane {
                         ));
                     } else {
                         let mut byte_cursor = 0;
-                        for cue in &cue_line.cues {
+                        for (cue_index, cue) in cue_line.cues.iter().enumerate() {
                             if cue.byte_start >= byte_cursor
                                 && let Some(gap) = cue_line.text.get(byte_cursor..cue.byte_start)
                                 && !gap.is_empty()
@@ -430,19 +602,37 @@ impl LyricsPane {
                                     show_furigana,
                                     reading_language,
                                 ));
+                                if let Some(line) = romanization_line.as_ref() {
+                                    line.append(&gtk::Label::new(Some(gap)));
+                                }
                             }
                             let text = cue_line
                                 .text
                                 .get(cue.byte_start..cue.byte_end_exclusive)
                                 .unwrap_or(&cue.text);
-                            let widget = lyrics_reading_unit(text, show_furigana, reading_language);
+                            let (widget, romanization) = lyrics_karaoke_unit(
+                                text,
+                                show_furigana,
+                                show_romanization,
+                                reading_language,
+                            );
                             widget.add_css_class("lyrics-cue");
                             cue_line_widget.append(&widget);
-                            cue_highlights.push(LyricsCueHighlight {
-                                cue: cue.clone(),
-                                widget,
+                            let romanization = romanization_line.as_ref().map(|line| {
+                                let label =
+                                    KaraokeText::new(romanization.as_deref().unwrap_or(text));
+                                line.append(&label);
+                                label
                             });
+                            let mut cue = cue.clone();
+                            cue.end_millis =
+                                effective_cue_end(&document.lines, line_index, cue_line, cue_index);
                             byte_cursor = byte_cursor.max(cue.byte_end_exclusive);
+                            cue_highlights.push(LyricsCueHighlight {
+                                cue,
+                                units: lyrics_reading_units(&widget),
+                                parallels: romanization.into_iter().collect(),
+                            });
                         }
                         if let Some(tail) = cue_line.text.get(byte_cursor..)
                             && !tail.is_empty()
@@ -452,9 +642,15 @@ impl LyricsPane {
                                 show_furigana,
                                 reading_language,
                             ));
+                            if let Some(line) = romanization_line.as_ref() {
+                                line.append(&gtk::Label::new(Some(tail)));
+                            }
                         }
                     }
                     cue_part.append(&cue_line_widget);
+                    if let Some(line) = romanization_line {
+                        cue_part.append(&line);
+                    }
                     content.append(&cue_part);
                 }
             } else if show_furigana && let Some(reading) = reading.as_ref() {
@@ -465,7 +661,10 @@ impl LyricsPane {
                 content.append(&label);
             }
 
-            if show_romanization && let Some(reading) = reading {
+            if show_romanization
+                && cue_highlights.is_empty()
+                && let Some(reading) = reading
+            {
                 let label = lyrics_label(&reading.romanization);
                 label.add_css_class("lyrics-romanization");
                 content.append(&label);
@@ -511,10 +710,17 @@ impl LyricsPane {
         let highlight_all_lines =
             lyrics.is_some_and(|lyrics| should_highlight_all_lyrics_lines(lyrics.lines.as_slice()));
         let previous_index = self.active_index.replace(active_index);
+        let full_row_sync = karaoke_rows_need_full_sync(previous_index, active_index);
         let follow_pause = self.follow_scroll_pause();
         let scroll_target = {
             let rows = self.rows.borrow();
             for row in rows.iter() {
+                if !full_row_sync
+                    && Some(row.line_index) != previous_index
+                    && Some(row.line_index) != active_index
+                {
+                    continue;
+                }
                 let active = row.track == LyricsRowTrack::Primary
                     && (highlight_all_lines || Some(row.line_index) == active_index);
                 if active {
@@ -522,29 +728,11 @@ impl LyricsPane {
                 } else {
                     row.row.remove_css_class("lyrics-row-active");
                 }
-                let latest_started_cue = row
-                    .cues
-                    .iter()
-                    .filter(|cue| position_millis >= i128::from(cue.cue.start_millis))
-                    .map(|cue| cue.cue.start_millis)
-                    .max();
                 for cue in &row.cues {
-                    if position_millis >= i128::from(cue.cue.start_millis) {
-                        cue.widget.add_css_class("lyrics-cue-sung");
-                    } else {
-                        cue.widget.remove_css_class("lyrics-cue-sung");
-                    }
-                    let cue_active = match cue.cue.end_millis {
-                        Some(end) => {
-                            position_millis >= i128::from(cue.cue.start_millis)
-                                && position_millis < i128::from(end)
-                        }
-                        None => latest_started_cue == Some(cue.cue.start_millis),
-                    };
-                    if cue_active {
-                        cue.widget.add_css_class("lyrics-cue-active");
-                    } else {
-                        cue.widget.remove_css_class("lyrics-cue-active");
+                    let progress = karaoke_cue_progress(&cue.cue, position_millis);
+                    set_karaoke_unit_progress(&cue.units, progress);
+                    for text in &cue.parallels {
+                        text.set_progress(progress);
                     }
                 }
             }
@@ -642,6 +830,15 @@ impl LyricsPane {
     }
 }
 
+fn karaoke_rows_need_full_sync(previous: Option<usize>, current: Option<usize>) -> bool {
+    match (previous, current) {
+        (Some(previous), Some(current)) => {
+            current < previous || current > previous.saturating_add(1)
+        }
+        (Some(_), None) | (None, _) => true,
+    }
+}
+
 fn lyrics_label(text: &str) -> gtk::Label {
     let label = gtk::Label::new(Some(text));
     label.set_wrap(true);
@@ -663,17 +860,95 @@ fn ruby_line(segments: &[JapaneseReadingSegment]) -> WrappingLine {
 }
 
 fn lyrics_reading_unit(text: &str, show_furigana: bool, language: Option<&str>) -> gtk::Widget {
-    if show_furigana
-        && let Some(reading) = japanese_reading_for_language_options(text, language, true, false)
-    {
+    lyrics_karaoke_unit(text, show_furigana, false, language).0
+}
+
+fn lyrics_karaoke_unit(
+    text: &str,
+    show_furigana: bool,
+    show_romanization: bool,
+    language: Option<&str>,
+) -> (gtk::Widget, Option<String>) {
+    let reading = (show_furigana || show_romanization)
+        .then(|| {
+            japanese_reading_for_language_options(text, language, show_furigana, show_romanization)
+        })
+        .flatten();
+    let widget = if show_furigana && let Some(reading) = reading.as_ref() {
         let phrase = gtk::Box::new(gtk::Orientation::Horizontal, 0);
         phrase.set_valign(gtk::Align::Baseline);
         for segment in &reading.segments {
             phrase.append(&ruby_segment(segment));
         }
-        return phrase.upcast();
+        phrase.upcast()
+    } else {
+        reading_surface_label(text).upcast()
+    };
+    let romanization = show_romanization
+        .then(|| reading.map(|reading| reading.romanization))
+        .flatten();
+    (widget, romanization)
+}
+
+fn lyrics_reading_units(widget: &gtk::Widget) -> Vec<KaraokeUnit> {
+    let mut furigana = Vec::new();
+    let mut units = Vec::new();
+    for text in karaoke_texts(widget) {
+        if text.has_css_class("lyrics-furigana") {
+            furigana.push(text);
+            continue;
+        }
+        if !text.has_css_class("lyrics-reading-surface") {
+            continue;
+        }
+        let characters = text.characters();
+        furigana.push(text);
+        units.push(KaraokeUnit {
+            characters,
+            texts: std::mem::take(&mut furigana),
+        });
     }
-    reading_surface_label(text).upcast()
+    units
+}
+
+fn karaoke_texts(widget: &gtk::Widget) -> Vec<KaraokeText> {
+    if let Ok(text) = widget.clone().downcast::<KaraokeText>() {
+        return vec![text];
+    }
+    std::iter::successors(widget.first_child(), gtk::Widget::next_sibling)
+        .flat_map(|child| karaoke_texts(&child))
+        .collect()
+}
+
+fn karaoke_cue_progress(cue: &LyricsCue, position_millis: i128) -> f64 {
+    let start = i128::from(cue.start_millis);
+    if position_millis <= start {
+        return 0.0;
+    }
+    let Some(end) = cue.end_millis.map(i128::from) else {
+        return 1.0;
+    };
+    if end <= start {
+        return 1.0;
+    }
+    ((position_millis - start) as f64 / (end - start) as f64).clamp(0.0, 1.0)
+}
+
+fn set_karaoke_unit_progress(units: &[KaraokeUnit], progress: f64) {
+    let progress = progress.clamp(0.0, 1.0);
+    let mut highlighted = units.iter().map(|unit| unit.characters).sum::<usize>() as f64 * progress;
+    for unit in units {
+        let characters = unit.characters as f64;
+        let unit_progress = if characters == 0.0 {
+            progress
+        } else {
+            (highlighted / characters).clamp(0.0, 1.0)
+        };
+        highlighted = (highlighted - characters).max(0.0);
+        for text in &unit.texts {
+            text.set_progress(unit_progress);
+        }
+    }
 }
 
 fn ruby_segment(segment: &JapaneseReadingSegment) -> gtk::Box {
@@ -685,18 +960,18 @@ fn ruby_segment(segment: &JapaneseReadingSegment) -> gtk::Box {
         segment_box.add_css_class("lyrics-ruby-annotated");
     }
 
-    let furigana = gtk::Label::new(Some(segment.furigana.as_deref().unwrap_or(" ")));
-    furigana.add_css_class("lyrics-furigana");
+    let furigana = KaraokeText::new(segment.furigana.as_deref().unwrap_or(" "));
+    furigana.add_text_class("lyrics-furigana");
     furigana.set_halign(gtk::Align::Center);
     segment_box.append(&furigana);
     segment_box.append(&reading_surface_label(&segment.surface));
     segment_box
 }
 
-fn reading_surface_label(text: &str) -> gtk::Label {
-    let label = gtk::Label::new(Some(text));
-    label.add_css_class("lyrics-reading-surface");
-    label.add_css_class("lyrics-scroll-anchor");
+fn reading_surface_label(text: &str) -> KaraokeText {
+    let label = KaraokeText::new(text);
+    label.add_text_class("lyrics-reading-surface");
+    label.add_text_class("lyrics-scroll-anchor");
     label.set_halign(gtk::Align::Center);
     label
 }
@@ -848,6 +1123,53 @@ pub(crate) fn next_lyrics_line_start_after(
         .min()
 }
 
+pub(crate) fn next_lyrics_highlight_after(
+    lines: &[LyricsLine],
+    position_millis: i128,
+) -> Option<u64> {
+    let active_end = lines
+        .iter()
+        .enumerate()
+        .flat_map(|(line_index, line)| {
+            line.cue_lines.iter().flat_map(move |cue_line| {
+                cue_line
+                    .cues
+                    .iter()
+                    .enumerate()
+                    .filter_map(move |(cue_index, cue)| {
+                        let end = effective_cue_end(lines, line_index, cue_line, cue_index)?;
+                        (i128::from(cue.start_millis) <= position_millis
+                            && position_millis < i128::from(end))
+                        .then_some(end)
+                    })
+            })
+        })
+        .min();
+    if let Some(end) = active_end {
+        return Some(
+            u64::try_from(position_millis.max(0))
+                .unwrap_or_default()
+                .saturating_add(KARAOKE_FRAME_MILLIS)
+                .min(end),
+        );
+    }
+    next_lyrics_line_start_after(lines, position_millis)
+}
+
+fn effective_cue_end(
+    lines: &[LyricsLine],
+    line_index: usize,
+    cue_line: &LyricsCueLine,
+    cue_index: usize,
+) -> Option<u64> {
+    cue_line.cues[cue_index]
+        .end_millis
+        .or_else(|| cue_line.cues.get(cue_index + 1).map(|cue| cue.start_millis))
+        .or(cue_line.end_millis)
+        .or(lines[line_index].end_millis)
+        .or_else(|| lines.get(line_index + 1).and_then(|line| line.start_millis))
+}
+
 pub(crate) fn lyrics_follow_scroll_pause_state(
     paused_until: Option<Instant>,
     now: Instant,
@@ -914,12 +1236,22 @@ fn lyrics_control_button(icon_name: &str) -> gtk::Button {
 mod tests {
     use super::{
         LyricsFollowScrollPause, active_lyrics_line_index, centered_scroll_target,
-        lyrics_follow_scroll_pause_state, lyrics_follow_scroll_target,
-        lyrics_scroll_animation_millis, next_lyrics_line_start_after,
-        should_highlight_all_lyrics_lines,
+        karaoke_cue_progress, karaoke_rows_need_full_sync, lyrics_follow_scroll_pause_state,
+        lyrics_follow_scroll_target, lyrics_scroll_animation_millis, next_lyrics_highlight_after,
+        next_lyrics_line_start_after, should_highlight_all_lyrics_lines,
     };
     use lyrics::{LyricsCue, LyricsCueLine, LyricsLine as LyricLine};
     use std::time::{Duration, Instant};
+
+    #[test]
+    fn karaoke_frames_resync_only_after_nonsequential_transitions() {
+        assert!(karaoke_rows_need_full_sync(None, Some(4)));
+        assert!(!karaoke_rows_need_full_sync(Some(4), Some(4)));
+        assert!(!karaoke_rows_need_full_sync(Some(4), Some(5)));
+        assert!(karaoke_rows_need_full_sync(Some(4), Some(7)));
+        assert!(karaoke_rows_need_full_sync(Some(4), Some(2)));
+        assert!(karaoke_rows_need_full_sync(Some(4), None));
+    }
 
     #[test]
     fn sync_lyrics_started() {
@@ -1037,6 +1369,29 @@ mod tests {
         }];
 
         assert_eq!(next_lyrics_line_start_after(&[karaoke], 1_000), Some(1_400));
+    }
+
+    #[test]
+    fn karaoke_cues_advance_continuously_through_the_word() {
+        let cue = LyricsCue {
+            text: "word".to_string(),
+            start_millis: 1_000,
+            end_millis: Some(1_400),
+            byte_start: 0,
+            byte_end_exclusive: 4,
+        };
+        assert_eq!(karaoke_cue_progress(&cue, 1_000), 0.0);
+        assert_eq!(karaoke_cue_progress(&cue, 1_200), 0.5);
+        assert_eq!(karaoke_cue_progress(&cue, 1_400), 1.0);
+        let mut line = line("word", Some(1_000));
+        line.cue_lines = vec![LyricsCueLine {
+            text: line.text.clone(),
+            start_millis: Some(1_000),
+            end_millis: Some(1_400),
+            agent_id: None,
+            cues: vec![cue],
+        }];
+        assert_eq!(next_lyrics_highlight_after(&[line], 1_000), Some(1_016));
     }
 
     #[test]

--- a/crates/ui/src/preferences/dialogs/metadata.rs
+++ b/crates/ui/src/preferences/dialogs/metadata.rs
@@ -111,13 +111,65 @@ pub(crate) fn present_metadata_dialog(shell: &Rc<Shell>, item: MetadataItemId) {
         match draft {
             Ok(draft) => build_dialog(&shell, selected, item, draft),
             Err(SourceMetadataError::LocalAccessRequired { source_path }) => {
-                present_local_access_recovery(&shell, selected, item, &source_path)
+                let retry_shell = Rc::downgrade(&shell);
+                present_local_access_recovery(
+                    &shell,
+                    selected,
+                    &source_path,
+                    Rc::new(move || {
+                        if let Some(shell) = retry_shell.upgrade() {
+                            present_metadata_dialog(&shell, item);
+                        }
+                    }),
+                );
             }
-            Err(SourceMetadataError::Unavailable) => present_metadata_error(
-                &shell,
-                &tr(msgid("Metadata editing is no longer available")),
-            ),
+            Err(SourceMetadataError::Unavailable) => {
+                shell.show_feedback_toast(tr(msgid("Metadata editing is no longer available")))
+            }
             Err(error) => present_metadata_error(&shell, &error.to_string()),
+        }
+    });
+}
+
+pub(crate) fn ensure_track_metadata_available(
+    shell: &Rc<Shell>,
+    track: library::TrackKey,
+    on_ready: Rc<dyn Fn()>,
+) {
+    let Some(selected) = shell.selected_library().as_deref().cloned() else {
+        return;
+    };
+    let receiver = selected.operations.track_metadata(track);
+    let shell = Rc::downgrade(shell);
+    gtk::glib::spawn_future_local(async move {
+        let result = receiver
+            .recv()
+            .await
+            .unwrap_or(Err(SourceMetadataError::Unavailable));
+        let Some(shell) = shell.upgrade() else { return };
+        if !selected_metadata_source_is_current(&shell, &selected) {
+            return;
+        }
+        match result {
+            Ok(_) => on_ready(),
+            Err(SourceMetadataError::LocalAccessRequired { source_path }) => {
+                let retry_shell = Rc::downgrade(&shell);
+                let retry_ready = Rc::clone(&on_ready);
+                present_local_access_recovery(
+                    &shell,
+                    selected,
+                    &source_path,
+                    Rc::new(move || {
+                        if let Some(shell) = retry_shell.upgrade() {
+                            ensure_track_metadata_available(&shell, track, Rc::clone(&retry_ready));
+                        }
+                    }),
+                );
+            }
+            Err(SourceMetadataError::Unavailable) => {
+                shell.show_feedback_toast(tr(msgid("Metadata editing is no longer available")))
+            }
+            Err(error) => shell.show_feedback_toast(error.to_string()),
         }
     });
 }
@@ -178,8 +230,8 @@ impl MetadataReceiver {
 fn present_local_access_recovery(
     shell: &Rc<Shell>,
     selected: crate::runtime::SelectedLibrary,
-    item: MetadataItemId,
     source_path: &str,
+    on_success: Rc<dyn Fn()>,
 ) {
     let dialog = adw::Dialog::builder()
         .title(tr(msgid("Edit metadata")))
@@ -192,11 +244,12 @@ fn present_local_access_recovery(
     header.set_title_widget(Some(&adw::WindowTitle::new(&tr("Edit metadata"), "")));
     let toolbar = adw::ToolbarView::new();
     toolbar.add_top_bar(&header);
-    let shell_for_retry = Rc::downgrade(shell);
+    let close = dialog.downgrade();
     let retry: Rc<dyn Fn()> = Rc::new(move || {
-        if let Some(shell) = shell_for_retry.upgrade() {
-            present_metadata_dialog(&shell, item);
+        if let Some(dialog) = close.upgrade() {
+            dialog.close();
         }
+        on_success();
     });
     let form = crate::preferences::source::local_access::metadata_local_access_recovery_form(
         shell,
@@ -241,9 +294,7 @@ fn build_dialog(
     save.add_css_class("suggested-action");
     save.set_sensitive(false);
     let bottom_actions = gtk::Box::new(gtk::Orientation::Horizontal, 8);
-    bottom_actions.set_halign(gtk::Align::End);
-    bottom_actions.append(&cancel);
-    bottom_actions.append(&save);
+    bottom_actions.set_hexpand(true);
 
     let staging = gtk::Box::new(gtk::Orientation::Vertical, 0);
     let mut entries = Vec::new();
@@ -270,18 +321,23 @@ fn build_dialog(
 
     let status = gtk::Label::new(None);
     status.set_halign(gtk::Align::Start);
-    status.set_wrap(true);
+    status.set_valign(gtk::Align::Center);
+    status.set_hexpand(true);
+    status.set_ellipsize(gtk::pango::EllipsizeMode::End);
     status.add_css_class("error");
     status.set_visible(false);
-    let footer = gtk::Box::new(gtk::Orientation::Vertical, 12);
-    footer.append(&status);
-    footer.append(&bottom_actions);
+    let status_slot = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    status_slot.set_hexpand(true);
+    status_slot.append(&status);
+    bottom_actions.append(&status_slot);
+    bottom_actions.append(&cancel);
+    bottom_actions.append(&save);
     let footer_clamp = adw::Clamp::new();
     footer_clamp.set_maximum_size(EDITOR_WIDTH);
     footer_clamp.set_margin_start(24);
     footer_clamp.set_margin_end(24);
     footer_clamp.set_margin_bottom(14);
-    footer_clamp.set_child(Some(&footer));
+    footer_clamp.set_child(Some(&bottom_actions));
 
     let body = gtk::Box::new(gtk::Orientation::Vertical, 12);
     body.append(&scroller);
@@ -1176,6 +1232,7 @@ impl Editor {
     }
     fn show_error(&self, message: &str) {
         self.status.set_label(message);
+        self.status.set_tooltip_text(Some(message));
         self.status.set_visible(true);
     }
 

--- a/crates/ui/src/preferences/source/local_access.rs
+++ b/crates/ui/src/preferences/source/local_access.rs
@@ -21,7 +21,6 @@ use super::login::{
     source_settings_group,
 };
 use crate::layout::large_popup_content_width;
-use crate::player::state::current_playback_track;
 use crate::shell::Shell;
 use crate::shell::actions::text_button;
 
@@ -127,7 +126,6 @@ impl LocalAccessEditor {
             }
             if let (Some(source_path), Some(server_prefix)) =
                 (source_path.as_deref(), editor.server_prefix.upgrade())
-                && server_prefix.text().trim().is_empty()
                 && let Some(suggested) = infer_server_prefix_for_root(source_path, &path)
             {
                 server_prefix.set_text(&suggested);
@@ -233,27 +231,7 @@ fn manage_server_content(
         let selected = configured.selected_source_id.as_ref() == Some(&server.id);
         (access, status, selected)
     };
-    let current_sample = {
-        let player = shell.selected_playback();
-        let source_id = shell.selected_library().as_deref().and_then(|selected| {
-            player
-                .as_ref()
-                .is_some_and(|player| player.transport.source_id == selected.source_key)
-                .then(|| selected.artwork.source_id.clone())
-        });
-        let source_path = current_playback_track(player.as_deref())
-            .and_then(|track| track.media_uri)
-            .and_then(|uri| gio::File::for_uri(&uri).path())
-            .map(|path| path.to_string_lossy().into_owned());
-        source_id.zip(source_path)
-    };
-    let sample_source_path = preferred_server_sample(
-        &server.id,
-        current_sample
-            .as_ref()
-            .map(|(source_id, source_path)| (source_id, source_path.as_str())),
-        access_status.sample_source_path.as_deref(),
-    );
+    let sample_source_path = access_status.sample_source_path.clone();
     let scroller = gtk::ScrolledWindow::new();
     scroller.set_policy(gtk::PolicyType::Never, gtk::PolicyType::Automatic);
     scroller.set_vexpand(true);
@@ -1048,17 +1026,6 @@ fn local_access_recovery_view(
     }
 }
 
-fn preferred_server_sample(
-    source_id: &SourceId,
-    current: Option<(&SourceId, &str)>,
-    cached: Option<&str>,
-) -> Option<String> {
-    current
-        .filter(|(current_source_id, _)| *current_source_id == source_id)
-        .map(|(_, source_path)| source_path.to_string())
-        .or_else(|| cached.map(str::to_string))
-}
-
 fn local_access_replacement_state(
     source_path: &str,
     server_prefix: &str,
@@ -1248,7 +1215,7 @@ fn infer_server_prefix_for_root(source_path: &str, root: &Path) -> Option<String
             .fold(root.to_path_buf(), |path, part| path.join(part.value));
         if candidate.is_file() {
             let suffix_len = parts.len().checked_sub(suffix_start)?;
-            return prefix_before_suffix(source_path, &parts, suffix_len);
+            return Some(prefix_before_suffix(source_path, &parts, suffix_len).unwrap_or_default());
         }
     }
     None
@@ -1387,35 +1354,6 @@ mod tests {
     }
 
     #[test]
-    fn current_track_from_the_managed_source_is_the_server_sample() {
-        let managed = SourceId::new("navidrome:server:managed");
-        let other = SourceId::new("jellyfin:server:other");
-
-        assert_eq!(
-            preferred_server_sample(
-                &managed,
-                Some((&managed, "/music/Current.flac")),
-                Some("/music/Cached.flac"),
-            )
-            .as_deref(),
-            Some("/music/Current.flac")
-        );
-        assert_eq!(
-            preferred_server_sample(
-                &managed,
-                Some((&other, "/other/Current.flac")),
-                Some("/music/Cached.flac"),
-            )
-            .as_deref(),
-            Some("/music/Cached.flac")
-        );
-        assert_eq!(
-            preferred_server_sample(&managed, Some((&other, "/other/Current.flac")), None),
-            None
-        );
-    }
-
-    #[test]
     fn chosen_music_folder_is_not_duplicated_as_a_local_prefix() {
         let root = PathBuf::from("/local/music");
         let input = source_local_access(
@@ -1469,6 +1407,10 @@ mod tests {
         assert_eq!(
             infer_server_prefix_for_root("/music/Artist/Album/Track.flac", directory.path()),
             Some("/music".to_string())
+        );
+        assert_eq!(
+            infer_server_prefix_for_root("Artist/Album/Track.flac", directory.path()),
+            Some(String::new())
         );
         assert_eq!(
             infer_server_prefix_for_root("/music/Artist/Album/Missing.flac", directory.path()),

--- a/crates/ui/src/shell/events.rs
+++ b/crates/ui/src/shell/events.rs
@@ -195,6 +195,7 @@ fn apply_configured_sources(
         selected: previous.selected.clone(),
     };
     *shell.source.configured.borrow_mut() = configured;
+    shell.products.lyrics.refresh_write_access();
     finish_source_assignment(shell, previous, next);
     shell.update_bottom_player();
 }
@@ -961,6 +962,19 @@ fn apply_lyrics_event(shell: &Rc<Shell>, event: lyrics::LyricsEvent) {
                 == Some(&media_id)
             {
                 shell.apply_lyrics_saved(media_id, path);
+            }
+        }
+        lyrics::LyricsEvent::SourceSaveFailed { media_id, error } => {
+            if current_playback_media_id(shell.selected_playback().as_deref()).as_ref()
+                == Some(&media_id)
+            {
+                shell.show_feedback_toast(match error {
+                    sources::SourceMetadataError::Unavailable
+                    | sources::SourceMetadataError::LocalAccessRequired { .. } => {
+                        tr("Metadata editing is no longer available")
+                    }
+                    error => error.to_string(),
+                });
             }
         }
     }

--- a/crates/ui/src/style.css
+++ b/crates/ui/src/style.css
@@ -1504,6 +1504,13 @@ popover.slider-value-popover label {
     transform 360ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
+.lyrics-line,
+.lyrics-line .lyrics-reading-surface,
+.lyrics-line .lyrics-furigana,
+.lyrics-line .lyrics-romanization {
+  text-shadow: 0 0 4px var(--window-bg-color);
+}
+
 .lyrics-row-active .lyrics-line {
   color: var(--window-fg-color);
   font-weight: 800;
@@ -2045,16 +2052,20 @@ listview.queue-list row {
   font-size: 15px;
 }
 
-.lyrics-cue {
-  transition: color 80ms linear, opacity 80ms linear;
+.lyrics-highlight-swatch {
+  min-width: 28px;
+  min-height: 28px;
+  border-radius: 6px;
+  color: var(--lyrics-highlight-color, var(--accent-color));
+  background-color: var(--lyrics-highlight-color, var(--accent-color));
 }
 
-.lyrics-cue-sung {
+.lyrics-theme-accent-probe {
   color: var(--accent-color);
 }
 
-.lyrics-cue-active {
-  font-weight: 700;
+.lyrics-cue-sung {
+  color: var(--lyrics-highlight-color, var(--accent-color));
 }
 
 .lyrics-agent-name {

--- a/locales/rufin.pot
+++ b/locales/rufin.pot
@@ -387,6 +387,9 @@ msgstr ""
 msgid "Collections"
 msgstr ""
 
+msgid "Color for the active word during playback"
+msgstr ""
+
 msgid "Color scheme"
 msgstr ""
 
@@ -495,6 +498,9 @@ msgstr ""
 msgid "Default right sidebar"
 msgstr ""
 
+msgid "Default"
+msgstr ""
+
 msgid "Delete Playlist"
 msgstr ""
 
@@ -579,7 +585,13 @@ msgstr ""
 msgid "EPs"
 msgstr ""
 
+msgid "Edit Lyrics"
+msgstr ""
+
 msgid "Edit Smart Playlist"
+msgstr ""
+
+msgid "Edit lyrics"
 msgstr ""
 
 msgid "Edit metadata"
@@ -676,6 +688,12 @@ msgid "Folder"
 msgstr ""
 
 msgid "Folders"
+msgstr ""
+
+msgid "Font family"
+msgstr ""
+
+msgid "Font size (px)"
 msgstr ""
 
 msgid "Forget Server"
@@ -811,6 +829,12 @@ msgid "Jellyfin"
 msgstr ""
 
 msgid "Jellyfin, Navidrome, or OpenSubsonic"
+msgstr ""
+
+msgid "Karaoke Playback"
+msgstr ""
+
+msgid "Karaoke highlight color"
 msgstr ""
 
 msgid "Karaoke mode"
@@ -1543,9 +1567,6 @@ msgstr ""
 msgid "ReplayGain"
 msgstr ""
 
-msgid "Requires OpenSubsonic songLyrics v2"
-msgstr ""
-
 msgid "Reset equalizer"
 msgstr ""
 
@@ -1607,6 +1628,9 @@ msgid "Saved"
 msgstr ""
 
 msgid "Saved, sync to preview matches"
+msgstr ""
+
+msgid "Saves lyrics to your source"
 msgstr ""
 
 msgid "Saving..."
@@ -1950,6 +1974,9 @@ msgstr ""
 msgid "Type to search"
 msgstr ""
 
+msgid "Typography"
+msgstr ""
+
 msgid "UPnP"
 msgstr ""
 
@@ -1996,6 +2023,9 @@ msgid "User"
 msgstr ""
 
 msgid "Username"
+msgstr ""
+
+msgid "Uses available karaoke lyrics or fetches them from the internet"
 msgstr ""
 
 msgid "Verify server certificate"


### PR DESCRIPTION
Adds embedded lyrics support, auto-embed toggle, typography, lyrics editor, and karaoke playback.

### New features

- **Embedded lyrics priority:** reads lyrics from audio file tags (`ID3, Vorbis`) at resolve time, always prioritized over external providers. Supports word-by-word (karaoke) inline cue timestamps (`<mm:ss.xx>`) from embedded synced lyrics.
- **Auto-embed toggle:** opt-in toggle in Sources settings to write fetched lyrics back into audio file tags for offline playback. Off by default.
- **Manual lyrics editor:** edit and save lyrics from the lyrics panel with highlighted LRC timestamps. Word-by-word inline cues are preserved on save, so nothing is lost when editing synced lyrics.
- **Typography customization:** custom font family (`from system-installed fonts`) and font size for the lyrics panel.
- **Karaoke playback settings:** reorganized settings with a new **Karaoke Playback** section.